### PR TITLE
Improve help on tokens

### DIFF
--- a/cmd/axiom/dataset/dataset.go
+++ b/cmd/axiom/dataset/dataset.go
@@ -28,7 +28,10 @@ func NewDatasetCmd(f *cmdutil.Factory) *cobra.Command {
 			"IsManagement": "true",
 		},
 
-		PersistentPreRunE: cmdutil.NeedsActiveDeployment(f),
+		PersistentPreRunE: cmdutil.ChainRunFuncs(
+			cmdutil.NeedsActiveDeployment(f),
+			cmdutil.NeedsPersonalAccessToken(f),
+		),
 	}
 
 	cmd.AddCommand(newCreateCmd(f))

--- a/cmd/axiom/root/help.go
+++ b/cmd/axiom/root/help.go
@@ -156,6 +156,9 @@ func rootHelpFunc(io *terminal.IO) func(*cobra.Command, []string) {
 		if cmd.Example != "" {
 			helpEntries = append(helpEntries, helpEntry{"EXAMPLES", cmd.Example})
 		}
+		if _, ok := cmd.Annotations["help:credentials"]; ok {
+			helpEntries = append(helpEntries, helpEntry{"AUTHENTICATION", cmd.Annotations["help:credentials"]})
+		}
 		if _, ok := cmd.Annotations["help:environment"]; ok {
 			helpEntries = append(helpEntries, helpEntry{"ENVIRONMENT VARIABLES", cmd.Annotations["help:environment"]})
 		}

--- a/cmd/axiom/root/help_topic.go
+++ b/cmd/axiom/root/help_topic.go
@@ -9,6 +9,17 @@ import (
 )
 
 var topics = map[string]string{
+	"credentials": `
+		The supplied token can either be a Personal Access Token, created from
+		the profile page of the deployment or an Ingest Token, created from the
+		appropriate section in the deployments settings.
+
+		Be aware, that Ingest Tokens are only valid for ingestion! Using them
+		with Axiom CLI is encouraged for ingest-only situations but renders the 
+		CLI unable to do anything else. Use a Personal Access Token to get full
+		access to the deployment.
+	`,
+
 	"environment": `
 		AXM_DEPLOYMENT: The deployment to use. Overwrittes the choice loaded
 		from the configuration file.

--- a/cmd/axiom/root/root.go
+++ b/cmd/axiom/root/root.go
@@ -36,11 +36,14 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 
 		Example: heredoc.Doc(`
 			$ axiom auth login
-			$ cat /var/log/nginx/*.log | axiom ingest -d nginx-logs
-			$ axiom query -d nginx-logs
+			$ axiom version
+			$ cat /var/log/nginx/*.log | axiom ingest nginx-logs
 		`),
 
 		Annotations: map[string]string{
+			"help:credentials": heredoc.Doc(`
+				See 'axiom help credentials' for help and guidance on authentication.
+			`),
 			"help:environment": heredoc.Doc(`
 				See 'axiom help environment' for the list of supported environment variables.
 			`),
@@ -103,6 +106,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(versionCmd.NewVersionCmd(f, version.Print("Axiom CLI")))
 
 	// Help topics
+	cmd.AddCommand(newHelpTopic(f.IO, "credentials"))
 	cmd.AddCommand(newHelpTopic(f.IO, "environment"))
 
 	return cmd

--- a/cmd/axiom/stream/stream.go
+++ b/cmd/axiom/stream/stream.go
@@ -67,6 +67,7 @@ func NewStreamCmd(f *cmdutil.Factory) *cobra.Command {
 
 		PreRunE: cmdutil.ChainRunFuncs(
 			cmdutil.NeedsActiveDeployment(f),
+			cmdutil.NeedsPersonalAccessToken(f),
 			cmdutil.NeedsDatasets(f),
 		),
 

--- a/cmd/axiom/version/version.go
+++ b/cmd/axiom/version/version.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/axiomhq/cli/internal/cmdutil"
+	"github.com/axiomhq/cli/internal/config"
 )
 
 // NewVersionCmd creates and returns the version command.
@@ -15,12 +16,15 @@ func NewVersionCmd(f *cmdutil.Factory, version string) *cobra.Command {
 		Long: heredoc.Doc(`
 			Print the version and build details.
 			
-			When an active deployment is configured, its version will be fetched
-			and printed as well.
+			When an active deployment is configured with a Personal Access Token,
+			its version will be fetched and printed as well.
 		`),
 
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if _, ok := f.Config.GetActiveDeployment(); !ok {
+			if activeDeployment, ok := f.Config.GetActiveDeployment(); !ok {
+				cmd.Println(version)
+				return nil
+			} else if activeDeployment.TokenType != config.Personal {
 				cmd.Println(version)
 				return nil
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,8 +52,9 @@ func (c *Config) GetActiveDeployment() (Deployment, bool) {
 	if !ok {
 		if c.URLOverride != "" || c.TokenOverride != "" {
 			dep = Deployment{
-				URL:   c.URLOverride,
-				Token: c.TokenOverride,
+				URL:       c.URLOverride,
+				Token:     c.TokenOverride,
+				TokenType: Personal,
 			}
 			return dep, true
 		}
@@ -65,6 +66,7 @@ func (c *Config) GetActiveDeployment() (Deployment, bool) {
 	}
 	if c.TokenOverride != "" {
 		dep.Token = c.TokenOverride
+		dep.TokenType = Personal
 	}
 
 	return dep, true


### PR DESCRIPTION
This PR improves the user experience by adding two things:

* An additional help topic on the different token types and how they affect the CLI usage
* An explicit error message when running commands which do not support using an ingest-only token

![Screenshot 2021-02-17 at 12 29 35](https://user-images.githubusercontent.com/9931588/108198826-699f4280-711c-11eb-8f40-9f923ed9e609.png)

Overriding the token by flag or environment bypasses the check by assuming a personal token was passed. This is crucial because a deployment can be configured with an ingest token but a personal token can be specified as override.