### PR TITLE
Enable buildmode 'pie'

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,12 +11,12 @@ builds:
       env:
         - CGO_ENABLED=0
       flags:
-        - -buildmode=exe
+        - -buildmode=pie
         - -installsuffix=cgo
         - -trimpath
         - -tags="osusergo netgo static_build"
       ldflags:
-        - -s -w -extldflags "-fno-PIC -static"
+        - -s -w -extldflags "-fno-PIC -static -Wl -z now -z relro"
         - -X github.com/axiomhq/cli/pkg/version.release={{ .Version }}
         - -X github.com/axiomhq/cli/pkg/version.revision={{ .ShortCommit }}
         - -X github.com/axiomhq/cli/pkg/version.buildDate={{ .CommitDate }}
@@ -27,18 +27,27 @@ builds:
       - darwin
     goarch: 
       - amd64
+      - arm64
 
   - <<: *build_defaults
     id: linux
     goos: 
       - linux
     goarch: 
-      - 386
       - amd64
       - arm64
     goarm: 
       - 6
       - 7
+    
+  - <<: *build_defaults
+    flags:
+      - -buildmode=exe
+    id: linux-no-pie
+    goos: 
+      - linux
+    goarch: 
+      - 386
 
   - <<: *build_defaults
     id: windows
@@ -55,6 +64,7 @@ archives:
     builds:
       - darwin
       - linux
+      - linux-no-pie
     wrap_in_directory: true
     format: tar.gz
     files:

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ MANPAGES_DIR	:= man
 GOTAGS := osusergo netgo static_build
 
 # FLAGS
-GOFLAGS := -buildmode=exe -tags='$(GOTAGS)' -installsuffix=cgo -trimpath
-GOFLAGS += -ldflags='-s -w -extldflags "-fno-PIC -static"
+GOFLAGS := -buildmode=pie -tags='$(GOTAGS)' -installsuffix=cgo -trimpath
+GOFLAGS += -ldflags='-s -w -extldflags "-fno-PIC -static -Wl -z now -z relro"
 GOFLAGS += -X $(MOD_NAME)/pkg/version.release=$(RELEASE)
 GOFLAGS += -X $(MOD_NAME)/pkg/version.revision=$(REVISION)
 GOFLAGS += -X $(MOD_NAME)/pkg/version.buildDate=$(BUILD_DATE)


### PR DESCRIPTION
* Enable buildmode `pie` for all platforms expect `linux/386` (not supported)
* While at it, build binaries for new M1 Macs by enabling `darwin/amd64`