### PR TITLE
Fix missing GoReleaser build flags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,9 @@ builds:
   - <<: *build_defaults
     flags:
       - -buildmode=exe
+      - -installsuffix=cgo
+      - -trimpath
+      - -tags="osusergo netgo static_build"
     id: linux-no-pie
     goos:
       - linux
@@ -53,6 +56,9 @@ builds:
   - <<: *build_defaults
     flags:
       - -buildmode=exe
+      - -installsuffix=cgo
+      - -trimpath
+      - -tags="osusergo netgo static_build"
     id: docker
     goos:
       - linux


### PR DESCRIPTION
With #68 I forgot to add all the other flags now missing because they are not inherited from the `build_defaults` anymore.