### PR TITLE
Add '--no-spinner' flag to disable spinner

### DIFF
--- a/cmd/axiom/root/root.go
+++ b/cmd/axiom/root/root.go
@@ -71,6 +71,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			f.Config.Insecure = cmd.Flag("insecure").Changed
+			f.IO.EnableActivityIndicator(!cmd.Flag("no-spinner").Changed)
 
 			return nil
 		},
@@ -99,6 +100,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.PersistentFlags().StringP("token", "T", os.Getenv("AXM_TOKEN"), "Token to use")
 	cmd.PersistentFlags().StringP("url", "U", os.Getenv("AXM_URL"), "Url to use")
 	cmd.PersistentFlags().BoolP("insecure", "I", false, "Bypass certificate validation")
+	cmd.PersistentFlags().Bool("no-spinner", false, "Disable the activity indicator")
 
 	// Core commands
 	cmd.AddCommand(ingestCmd.NewIngestCmd(f))

--- a/pkg/terminal/io.go
+++ b/pkg/terminal/io.go
@@ -40,8 +40,9 @@ type IO struct {
 	colorScheme  *ColorScheme
 	colorEnabled bool
 
-	pagerCommand      string
-	activityIndicator *spinner.Spinner
+	pagerCommand             string
+	activityIndicator        *spinner.Spinner
+	activityIndicatorEnabled bool
 }
 
 // NewIO returns a new IO. It detects if a TTY is attached and detects if
@@ -78,6 +79,12 @@ func NewIO() *IO {
 	}
 
 	return io
+}
+
+// EnableActivityIndicator enables or disables the activity indicator. It does
+// not force-enable it, if no TTY is attached.
+func (io *IO) EnableActivityIndicator(enable bool) {
+	io.activityIndicatorEnabled = enable
 }
 
 // In returns the input reader.
@@ -183,7 +190,7 @@ func (io *IO) StartPager(ctx context.Context) (func(), error) {
 // function, when called, stops the spinner. When no TTY is attached, this is a
 // nop.
 func (io *IO) StartActivityIndicator() func() {
-	if !io.isStdoutTTY || !io.isStderrTTY {
+	if !io.isStdoutTTY || !io.isStderrTTY || !io.activityIndicatorEnabled {
 		return func() {}
 	}
 	io.activityIndicator.Start()


### PR DESCRIPTION
Adds a global `--no-spinner` flag to disable the spinner on the command line. This is useful, when tools in a pipe produce output as well, like `pv` in `cat myfile | pv | axiom ingest mydataset`.

Closes #81.