### PR TITLE
Improved testing

### DIFF
--- a/.github/workflows/dependent_pr.yml
+++ b/.github/workflows/dependent_pr.yml
@@ -1,0 +1,30 @@
+name: Dependent PRs
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'axiomhq'
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_READ_TOKEN: ${{ secrets.AXIOM_AUTOMATION_TOKEN }}
+        with:
+          label: dependent
+          keywords: depends on, blocked by, needs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GOVERSION: "1.16"
+  GOVERSION: "1.17"
 
 jobs:
   gen-diff:
@@ -37,11 +37,22 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - uses: golangci/golangci-lint-action@v2
+        with:
+          skip-go-installation: true
 
   test:
     name: Test
     needs: lint
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        include:
+          - os: ubuntu-latest
+            update-coverage: true
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -55,7 +66,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
       - run: make test
-      - uses: codecov/codecov-action@v1
+      - name: Update Coverage
+        if: matrix.update-coverage
+        uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
 
@@ -82,32 +95,62 @@ jobs:
           args: build --snapshot
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
-          path: dist/linux_linux_amd64/axiom
+          name: binaries
+          path: |
+            dist/darwin_darwin_amd64/axiom
+            dist/linux_linux_amd64/axiom
+            dist/windows_windows_amd64/axiom.exe
 
   binary-integration:
     name: Binary integration
     needs: build
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        include:
+          - os: macos-latest
+            goos: darwin
+          - os: ubuntu-latest
+            goos: linux
+          - os: windows-latest
+            goos: windows
+    runs-on: ${{ matrix.os }}
     env:
       AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
       AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+      DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.goos }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: binary
-      - run: chmod +x ./axiom
-      - run: ./axiom version -I
-      - run: ./axiom dataset create -n=cli-test-$GITHUB_RUN_ID -d="CLI Integration test $GITHUB_RUN_ID"
-      - run: cat testdata/logs.csv | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: cat testdata/logs.json | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: cat testdata/logs.ndjson | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: ./axiom ingest cli-test-$GITHUB_RUN_ID -f=testdata/logs.ndjson
-      - run: ./axiom ingest cli-test-$GITHUB_RUN_ID -f=testdata/logs.json -f=testdata/logs.csv
-      - run: ./axiom dataset info cli-test-$GITHUB_RUN_ID
-      - run: ./axiom dataset list
+          name: binaries
+          path: dist
+      - name: Test (Unix)
+        if: matrix.goos == 'darwin' || matrix.goos == 'linux'
+        run: |
+          chmod +x dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom
+          mv dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom /usr/local/bin/axiom
+          axiom version -I
+          axiom dataset create -n=cli-test-${{ env.DATASET_SUFFIX }} -d="CLI Integration test ${{ env.DATASET_SUFFIX }}"
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.json -f=testdata/logs.ndjson -f=testdata/logs.csv
+          axiom dataset info cli-test-${{ env.DATASET_SUFFIX }}
+          axiom dataset list
+      - name: Test (Windows)
+        if: matrix.goos == 'windows'
+        run: |
+          chmod +x dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom.exe
+          mv dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom.exe C:/Windows/System32/axiom.exe
+          axiom version -I
+          axiom dataset create -n=cli-test-${{ env.DATASET_SUFFIX }} -d="CLI Integration test ${{ env.DATASET_SUFFIX }}"
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.json
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.ndjson
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.csv
+          axiom dataset info cli-test-${{ env.DATASET_SUFFIX }}
+          axiom dataset list
       - name: Cleanup
-        if: ${{ always() }}
-        run: ./axiom dataset delete -f cli-test-$GITHUB_RUN_ID
+        if: always()
+        run: axiom dataset delete -f cli-test-${{ env.DATASET_SUFFIX }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GOVERSION: "1.16"
+  GOVERSION: "1.17"
 
 jobs:
   gen-diff:
@@ -37,11 +37,23 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - uses: golangci/golangci-lint-action@v2
+        with:
+          skip-go-installation: true
 
   test:
     name: Test
     needs: lint
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        include:
+          - os: ubuntu-latest
+            update-coverage: true
+            update-goreportcard: true
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -55,10 +67,14 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
       - run: make test
-      - uses: codecov/codecov-action@v1
+      - name: Update Coverage
+        if: matrix.update-coverage
+        uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-      - uses: creekorful/goreportcard-action@v1.0
+      - name: Update Go Report Card
+        if: matrix.update-goreportcard
+        uses: creekorful/goreportcard-action@v1.0
 
   build:
     name: Build
@@ -83,31 +99,61 @@ jobs:
           args: build --snapshot
       - uses: actions/upload-artifact@v2
         with:
-          name: binary
-          path: dist/linux_linux_amd64/axiom
+          name: binaries
+          path: |
+            dist/darwin_darwin_amd64/axiom
+            dist/linux_linux_amd64/axiom
+            dist/windows_windows_amd64/axiom.exe
 
   binary-integration:
     name: Binary integration
     needs: build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        include:
+          - os: macos-latest
+            goos: darwin
+          - os: ubuntu-latest
+            goos: linux
+          - os: windows-latest
+            goos: windows
+    runs-on: ${{ matrix.os }}
     env:
       AXIOM_TOKEN: ${{ secrets.TESTING_AZURE_1_STAGING_ACCESS_TOKEN }}
       AXIOM_URL: ${{ secrets.TESTING_AZURE_1_STAGING_DEPLOYMENT_URL }}
+      DATASET_SUFFIX: ${{ github.run_id }}-${{ matrix.goos }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
-          name: binary
-      - run: chmod +x ./axiom
-      - run: ./axiom version -I
-      - run: ./axiom dataset create -n=cli-test-$GITHUB_RUN_ID -d="CLI Integration test $GITHUB_RUN_ID"
-      - run: cat testdata/logs.csv | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: cat testdata/logs.json | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: cat testdata/logs.ndjson | ./axiom ingest cli-test-$GITHUB_RUN_ID
-      - run: ./axiom ingest cli-test-$GITHUB_RUN_ID -f=testdata/logs.ndjson
-      - run: ./axiom ingest cli-test-$GITHUB_RUN_ID -f=testdata/logs.json -f=testdata/logs.csv
-      - run: ./axiom dataset info cli-test-$GITHUB_RUN_ID
-      - run: ./axiom dataset list
+          name: binaries
+          path: dist
+      - name: Test (Unix)
+        if: matrix.goos == 'darwin' || matrix.goos == 'linux'
+        run: |
+          chmod +x dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom
+          echo "dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom" >> $GITHUB_PATH
+          axiom version -I
+          axiom dataset create -n=cli-test-${{ env.DATASET_SUFFIX }} -d="CLI Integration test ${{ env.DATASET_SUFFIX }}"
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.json -f=testdata/logs.ndjson -f=testdata/logs.csv
+          axiom dataset info cli-test-${{ env.DATASET_SUFFIX }}
+          axiom dataset list
+      - name: Test (Windows)
+        if: matrix.goos == 'windows'
+        run: |
+          chmod +x dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom
+          echo "dist/${{ matrix.goos }}_${{ matrix.goos }}_amd64/axiom.exe" >> $GITHUB_PATH
+          axiom version -I
+          axiom dataset create -n=cli-test-${{ env.DATASET_SUFFIX }} -d="CLI Integration test ${{ env.DATASET_SUFFIX }}"
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.json
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.ndjson
+          axiom ingest cli-test-${{ env.DATASET_SUFFIX }} -f=testdata/logs.csv
+          axiom dataset info cli-test-${{ env.DATASET_SUFFIX }}
+          axiom dataset list
       - name: Cleanup
-        if: ${{ always() }}
-        run: ./axiom dataset delete -f cli-test-$GITHUB_RUN_ID
+        if: always()
+        run: axiom dataset delete -f cli-test-${{ env.DATASET_SUFFIX }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  GOVERSION: "1.16"
+  GOVERSION: "1.17"
 
 jobs:
   release:
@@ -35,10 +35,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
       - uses: goreleaser/goreleaser-action@v2
         with:
           args: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -48,28 +48,28 @@ Binary releases are available on
 ### Install using [Homebrew](https://brew.sh)
 
 ```shell
- brew tap axiomhq/tap
- brew install axiom
+brew tap axiomhq/tap
+brew install axiom
 ```
 
 To update:
 
 ```shell
- brew upgrade axiom
+brew upgrade axiom
 ```
 
-### Install using `go get`
+### Install using `go install`
 
 ```shell
- go install github.com/axiomhq/cli/cmd/axiom@latest
+go install github.com/axiomhq/cli/cmd/axiom@latest
 ```
 
 ### Install from source
 
 ```shell
- git clone https://github.com/axiomhq/cli.git
- cd cli
- make install # Build and install binary into $GOPATH
+git clone https://github.com/axiomhq/cli.git
+cd cli
+make install # Build and install binary into $GOPATH
 ```
 
 ### Run the Docker image
@@ -77,8 +77,8 @@ To update:
 Docker images are available on [DockerHub][docker].
 
 ```shell
- docker pull axiomhq/cli
- docker run axiomhq/cli
+docker pull axiomhq/cli
+docker run axiomhq/cli
 ```
 
 ### Validate installation
@@ -93,12 +93,8 @@ Axiom CLI version 1.0.0
 ## Usage
 
 ```shell
- axiom <command> 
- axiom <command> <subcommand> [flags]
-
-# Run `help` for detailed information about commands
-
- axiom help <command>
+axiom <command>
+axiom <command> <subcommand> [flags]
 ```
 
 ## Documentation
@@ -157,14 +153,14 @@ For full command reference, see the list below, or visit
 
 ```shell
 # To get help on any information
- axiom help
+axiom help
 
 # For more information about a command.
- axiom <command> --help
- axiom <command> <subcommand> --help
+axiom <command> --help
+axiom <command> <subcommand> --help
+```
 
 Read the manual at https://docs.axiom.co/reference/CLI/
-```
 
 ## Contributing
 


### PR DESCRIPTION
* Run Go unit tests and binary integration test on all major three OS
* Only update coverage and and code quality report from tests that ran on ubuntu linux
* Introduce `AXIOM_DATASET_PREFIX` as in `axiom-node` and `axiom-go` to uniquely identify a test dataset if it should be left over
* Skip Go installation for the `lint` action
* Use `github.token` instead of `secrets.GITHUB_TOKEN`. The reason for this is that to unexperienced users it looks like `GITHUB_TOKEN` is configured as a repository secret like all the other secretes for the `secrets.*` key. This makes it a bit more implicit, where the token comes from.
* Some README fixes