### PR TITLE
Doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To update:
 ### Install using `go get`
 
 ```shell
- go get -u github.com/axiomhq/cli/cmd/axiom
+ go install github.com/axiomhq/cli/cmd/axiom@latest
 ```
 
 ### Install from source

--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,3 @@ require (
 	golang.org/x/tools v0.1.5
 	gotest.tools/gotestsum v1.6.4
 )
-
-replace github.com/pelletier/go-toml v1.8.1 => github.com/pelletier/go-toml v1.8.2-0.20201124181426-2e01f733df54

--- a/go.sum
+++ b/go.sum
@@ -853,7 +853,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml v1.8.2-0.20201124181426-2e01f733df54/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=


### PR DESCRIPTION
Prefer `go install` with a version over `go get`. Also drop a useless `replace` directive that would otherwise prevent `go install` to work.