### PR TITLE
Org-handling

### DIFF
--- a/internal/cmd/auth/auth_login.go
+++ b/internal/cmd/auth/auth_login.go
@@ -139,7 +139,7 @@ func completeLogin(ctx context.Context, opts *loginOptions) error {
 			return err
 		}
 
-		organizations, err := client.Organizations.Cloud.List(ctx)
+		organizations, err := client.Organizations.Selfhost.List(ctx)
 		if err != nil {
 			return err
 		}
@@ -236,8 +236,8 @@ func runLogin(ctx context.Context, opts *loginOptions) error {
 		cs := opts.IO.ColorScheme()
 
 		if user != nil {
-			if opts.URL == axiom.CloudURL && axiom.IsPersonalToken(opts.Token) {
-				organization, err := client.Organizations.Cloud.Get(ctx, opts.OrganizationID)
+			if (opts.URL == axiom.CloudURL || opts.Config.ForceCloud) && axiom.IsPersonalToken(opts.Token) {
+				organization, err := client.Organizations.Selfhost.Get(ctx, opts.OrganizationID)
 				if err != nil {
 					return err
 				}
@@ -249,7 +249,7 @@ func runLogin(ctx context.Context, opts *loginOptions) error {
 					cs.SuccessIcon(), cs.Bold(opts.Alias), cs.Bold(user.Name))
 			}
 		} else {
-			if opts.URL == axiom.CloudURL {
+			if opts.URL == axiom.CloudURL || opts.Config.ForceCloud {
 				fmt.Fprintf(opts.IO.ErrOut(), "%s Logged in to organization %s %s\n",
 					cs.SuccessIcon(), cs.Bold(opts.OrganizationID), cs.Red(cs.Bold("(ingestion only!)")))
 			} else {

--- a/internal/cmd/auth/auth_status.go
+++ b/internal/cmd/auth/auth_status.go
@@ -95,7 +95,7 @@ func runStatus(ctx context.Context, opts *statusOptions) error {
 						cs.Bold(user.Name))
 				} else {
 					var organization *axiom.Organization
-					if organization, err = client.Organizations.Cloud.Get(ctx, deployment.OrganizationID); err != nil {
+					if organization, err = client.Organizations.Selfhost.Get(ctx, deployment.OrganizationID); err != nil {
 						info = fmt.Sprintf("%s %s", cs.ErrorIcon(), err)
 						failed = true
 					} else {

--- a/internal/cmd/auth/auth_switch_org.go
+++ b/internal/cmd/auth/auth_switch_org.go
@@ -40,6 +40,7 @@ func newSwitchOrgCmd(f *cmdutil.Factory) *cobra.Command {
 		PreRunE: cmdutil.ChainRunFuncs(
 			cmdutil.NeedsDeployments(f),
 			cmdutil.NeedsActiveDeployment(f),
+			cmdutil.NeedsCloudDeployment(f),
 			cmdutil.NeedsPersonalAccessToken(f),
 		),
 
@@ -67,7 +68,7 @@ func newSwitchOrgCmd(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			organization, err := client.Organizations.Cloud.Get(cmd.Context(), orgID)
+			organization, err := client.Organizations.Selfhost.Get(cmd.Context(), orgID)
 			if err != nil {
 				return err
 			}
@@ -102,7 +103,7 @@ func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, erro
 	stop := f.IO.StartActivityIndicator()
 	defer stop()
 
-	organizations, err := client.Organizations.Cloud.List(ctx)
+	organizations, err := client.Organizations.Selfhost.List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/auth/auth_update_token.go
+++ b/internal/cmd/auth/auth_update_token.go
@@ -112,8 +112,8 @@ func runUpdateToken(ctx context.Context, opts *updateTokenOptions) error {
 		cs := opts.IO.ColorScheme()
 
 		if user != nil {
-			if activeDeployment.URL == axiom.CloudURL {
-				organization, err := client.Organizations.Cloud.Get(ctx, activeDeployment.OrganizationID)
+			if activeDeployment.URL == axiom.CloudURL || opts.Config.ForceCloud {
+				organization, err := client.Organizations.Selfhost.Get(ctx, activeDeployment.OrganizationID)
 				if err != nil {
 					return err
 				}
@@ -125,7 +125,7 @@ func runUpdateToken(ctx context.Context, opts *updateTokenOptions) error {
 					cs.SuccessIcon(), cs.Bold(opts.Config.ActiveDeployment), cs.Bold(user.Name))
 			}
 		} else {
-			if activeDeployment.URL == axiom.CloudURL {
+			if activeDeployment.URL == axiom.CloudURL || opts.Config.ForceCloud {
 				fmt.Fprintf(opts.IO.ErrOut(), "%s Logged in to organization %s %s\n",
 					cs.SuccessIcon(), cs.Bold(activeDeployment.OrganizationID), cs.Red(cs.Bold("(ingestion only!)")))
 			} else {

--- a/internal/cmd/dataset/dataset.go
+++ b/internal/cmd/dataset/dataset.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"context"
+	"sort"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
@@ -65,6 +66,7 @@ func getDatasetNames(ctx context.Context, f *cmdutil.Factory) ([]string, error) 
 	for i, dataset := range datasets {
 		datasetNames[i] = dataset.Name
 	}
+	sort.Strings(datasetNames)
 
 	return datasetNames, nil
 }

--- a/internal/cmd/organization/keys/keys.go
+++ b/internal/cmd/organization/keys/keys.go
@@ -1,0 +1,62 @@
+package keys
+
+import (
+	"context"
+	"sort"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/axiomhq/cli/internal/cmdutil"
+)
+
+// NewKeysCmd creates and returns the keys command.
+func NewKeysCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keys <command>",
+		Short: "Manage organization shared access keys",
+		Long:  "Manage organization shared access keys.",
+
+		Example: heredoc.Doc(`
+			$ axiom organization keys get
+			$ axiom organization keys rotate my-org-123
+			$ axiom organization keys get my-org-123
+		`),
+
+		Annotations: map[string]string{
+			"IsManagement": "true",
+		},
+
+		PersistentPreRunE: cmdutil.NeedsCloudDeployment(f),
+	}
+
+	cmd.AddCommand(newGetCmd(f))
+	cmd.AddCommand(newRotateCmd(f))
+
+	return cmd
+}
+
+func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, error) {
+	client, err := f.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stop := f.IO.StartActivityIndicator()
+	defer stop()
+
+	organizations, err := client.Organizations.Cloud.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stop()
+
+	organizationIDs := make([]string, len(organizations))
+	for i, organization := range organizations {
+		organizationIDs[i] = organization.ID
+	}
+	sort.Strings(organizationIDs)
+
+	return organizationIDs, nil
+}

--- a/internal/cmd/organization/keys/keys_get.go
+++ b/internal/cmd/organization/keys/keys_get.go
@@ -1,0 +1,137 @@
+package keys
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/axiomhq/cli/internal/cmdutil"
+	"github.com/axiomhq/cli/pkg/iofmt"
+)
+
+type getOptions struct {
+	*cmdutil.Factory
+
+	// ID of the organization to fetch keys of. If not supplied as an argument,
+	// which is optional, the user will be asked for it.
+	ID string
+	// Format to output data in. Defaults to tabular output.
+	Format string
+}
+
+func newGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &getOptions{
+		Factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get [<organization-id>] [(-f|--format=)json|table]",
+		Short: "Get shared access keys of an organization",
+
+		Args:              cmdutil.PopulateFromArgs(f, &opts.ID),
+		ValidArgsFunction: cmdutil.OrganizationCompletionFunc(f),
+
+		Example: heredoc.Doc(`
+			# Interactively get the shared access keys of an organization:
+			$ axiom organization keys get
+			
+			# Get the shared access keys of an organization and provide the
+			# organization id as an argument:
+			$ axiom organization keys get my-org-123
+		`),
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := completeGet(cmd.Context(), opts); err != nil {
+				return err
+			}
+			return runGet(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Format, "format", "f", iofmt.Table.String(), "Format to output data in")
+
+	_ = cmd.RegisterFlagCompletionFunc("format", cmdutil.FormatCompletion)
+
+	return cmd
+}
+
+func completeGet(ctx context.Context, opts *getOptions) error {
+	if opts.ID != "" {
+		return nil
+	}
+
+	organizationIDs, err := getOrganizationIDs(ctx, opts.Factory)
+	if err != nil {
+		return err
+	}
+
+	if len(organizationIDs) == 1 {
+		opts.ID = organizationIDs[0]
+		return nil
+	}
+
+	return survey.AskOne(&survey.Select{
+		Message: "Which organization to get the license for?",
+		Options: organizationIDs,
+	}, &opts.ID, opts.IO.SurveyIO())
+}
+
+func runGet(ctx context.Context, opts *getOptions) error {
+	client, err := opts.Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	progStop := opts.IO.StartActivityIndicator()
+	defer progStop()
+
+	organization, err := client.Organizations.Cloud.Get(ctx, opts.ID)
+	if err != nil {
+		return err
+	}
+
+	keys, err := client.Organizations.Cloud.ViewSharedAccessKeys(ctx, opts.ID)
+	if err != nil {
+		return err
+	}
+
+	progStop()
+
+	pagerStop, err := opts.IO.StartPager(ctx)
+	if err != nil {
+		return err
+	}
+	defer pagerStop()
+
+	if opts.Format == iofmt.JSON.String() {
+		return iofmt.FormatToJSON(opts.IO.Out(), keys, opts.IO.ColorEnabled())
+	}
+
+	cs := opts.IO.ColorScheme()
+
+	var header iofmt.HeaderBuilderFunc
+	if opts.IO.IsStdoutTTY() {
+		header = func(w io.Writer, trb iofmt.TableRowBuilder) {
+			fmt.Fprintf(opts.IO.Out(), "Showing shared access keys of organization %s:\n\n", cs.Bold(organization.Name))
+
+			trb.AddField("ID", cs.Bold)
+			trb.AddField("Key", cs.Bold)
+		}
+	}
+
+	contentRow := func(trb iofmt.TableRowBuilder, k int) {
+		if k == 0 {
+			trb.AddField("Primary", cs.Gray)
+			trb.AddField(keys.Primary, nil)
+		} else if k == 1 {
+			trb.AddField("Secondary", cs.Gray)
+			trb.AddField(keys.Secondary, nil)
+		}
+	}
+
+	return iofmt.FormatToTable(opts.IO, 2, header, nil, contentRow)
+}

--- a/internal/cmd/organization/keys/keys_rotate.go
+++ b/internal/cmd/organization/keys/keys_rotate.go
@@ -1,0 +1,166 @@
+package keys
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/axiomhq/cli/internal/cmdutil"
+	"github.com/axiomhq/cli/pkg/iofmt"
+	"github.com/axiomhq/cli/pkg/surveyext"
+)
+
+type rotateOptions struct {
+	*cmdutil.Factory
+
+	// ID of the organization to fetch keys of. If not supplied as an argument,
+	// which is optional, the user will be asked for it.
+	ID string
+	// Format to output data in. Defaults to tabular output.
+	Format string
+	// Force the deletion and skip the confirmation prompt.
+	Force bool
+}
+
+func newRotateCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &rotateOptions{
+		Factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "rotate [<organization-id>] [(-f|--format=)json|table] [-f|--force]",
+		Short: "Rotate shared access keys of an organization",
+
+		Args:              cmdutil.PopulateFromArgs(f, &opts.ID),
+		ValidArgsFunction: cmdutil.OrganizationCompletionFunc(f),
+
+		Example: heredoc.Doc(`
+			# Interactively rotate the shared access keys of an organization:
+			$ axiom organization keys rotate
+			
+			# Rotate the shared access keys of an organization and provide the
+			# organization id as an argument:
+			$ axiom organization keys rotate my-org-123
+		`),
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := completeRotate(cmd.Context(), opts); err != nil {
+				return err
+			}
+			return runRotate(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Format, "format", "f", iofmt.Table.String(), "Format to output data in")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip the confirmation prompt")
+
+	_ = cmd.RegisterFlagCompletionFunc("format", cmdutil.FormatCompletion)
+	_ = cmd.RegisterFlagCompletionFunc("force", cmdutil.NoCompletion)
+
+	if !opts.IO.IsStdinTTY() {
+		_ = cmd.MarkFlagRequired("force")
+	}
+
+	return cmd
+}
+
+func completeRotate(ctx context.Context, opts *rotateOptions) error {
+	if opts.ID != "" {
+		return nil
+	}
+
+	organizationIDs, err := getOrganizationIDs(ctx, opts.Factory)
+	if err != nil {
+		return err
+	}
+
+	if len(organizationIDs) == 1 {
+		opts.ID = organizationIDs[0]
+		return nil
+	}
+
+	return survey.AskOne(&survey.Select{
+		Message: "Which organization to get the license for?",
+		Options: organizationIDs,
+	}, &opts.ID, opts.IO.SurveyIO())
+}
+
+func runRotate(ctx context.Context, opts *rotateOptions) error {
+	client, err := opts.Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	progStop := opts.IO.StartActivityIndicator()
+	defer progStop()
+
+	organization, err := client.Organizations.Cloud.Get(ctx, opts.ID)
+	if err != nil {
+		return err
+	}
+
+	progStop()
+
+	// Deleting must be forced if not running interactively.
+	if !opts.IO.IsStdinTTY() && !opts.Force {
+		return cmdutil.ErrSilent
+	}
+
+	if !opts.Force {
+		msg := fmt.Sprintf("Rotate shared access keys for %q?", organization.Name)
+		var overwrite bool
+		if overwrite, err = surveyext.AskConfirm(msg, false, opts.IO.SurveyIO()); err != nil {
+			return err
+		} else if !overwrite {
+			return cmdutil.ErrSilent
+		}
+	}
+
+	progStop = opts.IO.StartActivityIndicator()
+	defer progStop()
+
+	keys, err := client.Organizations.Cloud.RotateSharedAccessKeys(ctx, opts.ID)
+	if err != nil {
+		return err
+	}
+
+	progStop()
+
+	pagerStop, err := opts.IO.StartPager(ctx)
+	if err != nil {
+		return err
+	}
+	defer pagerStop()
+
+	if opts.Format == iofmt.JSON.String() {
+		return iofmt.FormatToJSON(opts.IO.Out(), keys, opts.IO.ColorEnabled())
+	}
+
+	cs := opts.IO.ColorScheme()
+
+	var header iofmt.HeaderBuilderFunc
+	if opts.IO.IsStdoutTTY() {
+		header = func(w io.Writer, trb iofmt.TableRowBuilder) {
+			fmt.Fprintf(opts.IO.Out(), "Showing rotated shared access keys of organization %s:\n\n", cs.Bold(organization.Name))
+
+			trb.AddField("ID", cs.Bold)
+			trb.AddField("Key", cs.Bold)
+		}
+	}
+
+	contentRow := func(trb iofmt.TableRowBuilder, k int) {
+		if k == 0 {
+			trb.AddField("Primary", cs.Gray)
+			trb.AddField(keys.Primary, nil)
+		} else if k == 1 {
+			trb.AddField("Secondary", cs.Gray)
+			trb.AddField(keys.Secondary, nil)
+		}
+	}
+
+	return iofmt.FormatToTable(opts.IO, 2, header, nil, contentRow)
+}

--- a/internal/cmd/organization/organization.go
+++ b/internal/cmd/organization/organization.go
@@ -10,6 +10,8 @@ import (
 	"github.com/axiomhq/cli/pkg/terminal"
 )
 
+const defaultSelfhostOrganizationID = "axiom"
+
 // NewOrganizationCmd creates and returns the organization command.
 func NewOrganizationCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -49,7 +51,7 @@ func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, erro
 	stop := f.IO.StartActivityIndicator()
 	defer stop()
 
-	organizations, err := client.Organizations.Cloud.List(ctx)
+	organizations, err := client.Organizations.Selfhost.List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/organization/organization.go
+++ b/internal/cmd/organization/organization.go
@@ -2,12 +2,16 @@ package organization
 
 import (
 	"context"
+	"sort"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"github.com/axiomhq/cli/internal/cmdutil"
 	"github.com/axiomhq/cli/pkg/terminal"
+
+	// Subcommands
+	keysCmd "github.com/axiomhq/cli/internal/cmd/organization/keys"
 )
 
 const defaultSelfhostOrganizationID = "axiom"
@@ -23,6 +27,7 @@ func NewOrganizationCmd(f *cmdutil.Factory) *cobra.Command {
 			$ axiom organization list
 			$ axiom organization license my-org-123
 			$ axiom organization info my-org-123
+			$ axiom organization keys get my-org-123
 		`),
 
 		Annotations: map[string]string{
@@ -38,6 +43,9 @@ func NewOrganizationCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newInfoCmd(f))
 	cmd.AddCommand(newLicenseCmd(f))
 	cmd.AddCommand(newListCmd(f))
+
+	// Subcommands
+	cmd.AddCommand(keysCmd.NewKeysCmd(f))
 
 	return cmd
 }
@@ -62,6 +70,7 @@ func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, erro
 	for i, organization := range organizations {
 		organizationIDs[i] = organization.ID
 	}
+	sort.Strings(organizationIDs)
 
 	return organizationIDs, nil
 }

--- a/internal/cmd/organization/organization_info.go
+++ b/internal/cmd/organization/organization_info.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
+	"github.com/axiomhq/axiom-go/axiom"
 	"github.com/spf13/cobra"
 
 	"github.com/axiomhq/cli/internal/cmdutil"
@@ -61,6 +62,13 @@ func newInfoCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func completeInfo(ctx context.Context, opts *infoOptions) error {
+	// A requirement for this command to execute is the presence of an active
+	// deployment, so no need to check for existence.
+	activeDeployment, _ := opts.Config.GetActiveDeployment()
+	if activeDeployment.URL != axiom.CloudURL && !opts.Config.ForceCloud {
+		opts.ID = defaultSelfhostOrganizationID
+	}
+
 	if opts.ID != "" {
 		return nil
 	}
@@ -85,7 +93,7 @@ func runInfo(ctx context.Context, opts *infoOptions) error {
 	progStop := opts.IO.StartActivityIndicator()
 	defer progStop()
 
-	organization, err := client.Organizations.Cloud.Get(ctx, opts.ID)
+	organization, err := client.Organizations.Selfhost.Get(ctx, opts.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/organization/organization_info.go
+++ b/internal/cmd/organization/organization_info.go
@@ -78,6 +78,11 @@ func completeInfo(ctx context.Context, opts *infoOptions) error {
 		return err
 	}
 
+	if len(organizationIDs) == 1 {
+		opts.ID = organizationIDs[0]
+		return nil
+	}
+
 	return survey.AskOne(&survey.Select{
 		Message: "Which organization to get info for?",
 		Options: organizationIDs,

--- a/internal/cmd/organization/organization_info.go
+++ b/internal/cmd/organization/organization_info.go
@@ -41,7 +41,7 @@ func newInfoCmd(f *cmdutil.Factory) *cobra.Command {
 			# Interactively get info of an organization:
 			$ axiom organization info
 			
-			# Get info of an organization and provide the organization ID as an
+			# Get info of an organization and provide the organization id as an
 			# argument:
 			$ axiom organization info my-org-123
 		`),

--- a/internal/cmd/organization/organization_license.go
+++ b/internal/cmd/organization/organization_license.go
@@ -43,7 +43,7 @@ func newLicenseCmd(f *cmdutil.Factory) *cobra.Command {
 			# Interactively get the license of an organization:
 			$ axiom organization license
 			
-			# Get the license of an organization and provide the organization ID
+			# Get the license of an organization and provide the organization id
 			# as an argument:
 			$ axiom organization license my-org-123
 		`),

--- a/internal/cmd/organization/organization_license.go
+++ b/internal/cmd/organization/organization_license.go
@@ -80,6 +80,11 @@ func completeLicense(ctx context.Context, opts *licenseOptions) error {
 		return err
 	}
 
+	if len(organizationIDs) == 1 {
+		opts.ID = organizationIDs[0]
+		return nil
+	}
+
 	return survey.AskOne(&survey.Select{
 		Message: "Which organization to get the license for?",
 		Options: organizationIDs,

--- a/internal/cmd/organization/organization_license.go
+++ b/internal/cmd/organization/organization_license.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
+	"github.com/axiomhq/axiom-go/axiom"
 	"github.com/spf13/cobra"
 
 	"github.com/axiomhq/cli/internal/cmdutil"
@@ -63,6 +64,13 @@ func newLicenseCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func completeLicense(ctx context.Context, opts *licenseOptions) error {
+	// A requirement for this command to execute is the presence of an active
+	// deployment, so no need to check for existence.
+	activeDeployment, _ := opts.Config.GetActiveDeployment()
+	if activeDeployment.URL != axiom.CloudURL && !opts.Config.ForceCloud {
+		opts.ID = defaultSelfhostOrganizationID
+	}
+
 	if opts.ID != "" {
 		return nil
 	}
@@ -87,7 +95,7 @@ func runLicense(ctx context.Context, opts *licenseOptions) error {
 	progStop := opts.IO.StartActivityIndicator()
 	defer progStop()
 
-	organization, err := client.Organizations.Cloud.Get(ctx, opts.ID)
+	organization, err := client.Organizations.Selfhost.Get(ctx, opts.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/organization/organization_list.go
+++ b/internal/cmd/organization/organization_list.go
@@ -38,6 +38,8 @@ func newListCmd(f *cmdutil.Factory) *cobra.Command {
 			$ axiom organization list
 		`),
 
+		PreRunE: cmdutil.NeedsCloudDeployment(f),
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), opts)
 		},

--- a/internal/cmd/root/help.go
+++ b/internal/cmd/root/help.go
@@ -102,7 +102,7 @@ func rootHelpFunc(io *terminal.IO) func(*cobra.Command, []string) {
 				continue
 			}
 
-			s := padding.String(c.Name()+":", uint(c.NamePadding()+1)) + c.Short
+			s := padding.String(c.Name()+":", uint(c.NamePadding()+2)) + c.Short
 			if _, ok := c.Annotations["IsCore"]; ok {
 				coreCommands = append(coreCommands, s)
 			} else if _, ok := c.Annotations["IsManagement"]; ok {

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -24,7 +24,7 @@ var topics = map[string]string{
 		AXIOM_DEPLOYMENT: The deployment to use. Overwrittes the choice loaded
 		from the configuration file.
 
-		AXIOM_ORG_ID: The organization ID of the organization the access token
+		AXIOM_ORG_ID: The organization id of the organization the access token
 		is valid for. Only valid for Axiom Cloud.
 		
 		AXIOM_PAGER, PAGER (in order of precedence): A terminal paging program

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -73,6 +73,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			f.Config.Insecure = cmd.Flag("insecure").Changed
+			f.Config.ForceCloud = cmd.Flag("force-cloud").Changed
 			f.IO.EnableActivityIndicator(!cmd.Flag("no-spinner").Changed)
 
 			return nil
@@ -102,6 +103,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.PersistentFlags().StringP("token", "T", os.Getenv("AXIOM_TOKEN"), "Token to use")
 	cmd.PersistentFlags().StringP("url", "U", os.Getenv("AXIOM_URL"), "Url to use")
 	cmd.PersistentFlags().BoolP("insecure", "I", false, "Bypass certificate validation")
+	cmd.PersistentFlags().BoolP("force-cloud", "F", false, "Treat deployment as Axiom Cloud")
 	cmd.PersistentFlags().Bool("no-spinner", false, "Disable the activity indicator")
 
 	// Core commands

--- a/internal/cmdutil/completion.go
+++ b/internal/cmdutil/completion.go
@@ -82,7 +82,7 @@ func OrganizationCompletionFunc(f *Factory) CompletionFunc {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		organizations, err := client.Organizations.Cloud.List(ctx)
+		organizations, err := client.Organizations.Selfhost.List(ctx)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmdutil/completion.go
+++ b/internal/cmdutil/completion.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ func FormatCompletion(_ *cobra.Command, _ []string, toComplete string) ([]string
 			res = append(res, validFormat.String())
 		}
 	}
+	sort.Strings(res)
 	return res, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -60,6 +62,7 @@ func DatasetCompletionFunc(f *Factory) CompletionFunc {
 				res = append(res, dataset.Name)
 			}
 		}
+		sort.Strings(res)
 
 		return res, cobra.ShellCompDirectiveNoFileComp
 	}
@@ -93,6 +96,7 @@ func OrganizationCompletionFunc(f *Factory) CompletionFunc {
 				res = append(res, organization.ID)
 			}
 		}
+		sort.Strings(res)
 
 		return res, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	URLOverride            string `toml:"-" envconfig:"url"`
 	TokenOverride          string `toml:"-" envconfig:"token"`
 	OrganizationIDOverride string `toml:"-" envconfig:"org_id"`
+	ForceCloud             bool   `toml:"-" envconfig:"force_cloud"`
 
 	ConfigFilePath string `toml:"-"`
 


### PR DESCRIPTION
* Update to `axiom-go@v0.9.0`
* Properly dead with Selfhost vs Cloud
* Manage organization shared access keys
* Sort string literals for datasets, organization ids in prompts and completions
* Fix help padding