### PR TITLE
Allow api tokens on query and stream commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,27 +118,33 @@ For full command reference, see the list below, or visit
 
 **Management Commands**
 
-| Commands                   | Description                       |
-| -------------------------- | --------------------------------- |
-| axiom auth login           | Login to an Axiom deployment      |
-| axiom auth logout          | Logout of an Axiom deployment     |
-| axiom auth select          | Select an Axiom deployment        |
-| axiom auth status          | View authentication status        |
-| axiom auth switch-org      | Switch the organization           |
-| axiom auth update-token    | Update the token of a deloyment   |
-| axiom config edit          | Edit the configuration file       |
-| axiom config get           | Get a configuration value         |
-| axiom config set           | Set a configuration value         |
-| axiom dataset create       | Create a dataset                  |
-| axiom dataset delete       | Delete a dataset                  |
-| axiom dataset info         | Get info about a dataset          |
-| axiom dataset list         | List all datasets                 |
-| axiom dataset stats        | Get statistics about all datasets |
-| axiom dataset trim         | Trim a dataset to a given size    |
-| axiom dataset update       | Update a dataset                  |
-| axiom organization info    | Get info about an organization    |
-| axiom organization license | Get an organizations license      |
-| axiom organization list    | List all organizations            |
+| Commands                       | Description                                  |
+| ------------------------------ | -------------------------------------------- |
+| axiom auth login               | Login to an Axiom deployment                 |
+| axiom auth logout              | Logout of an Axiom deployment                |
+| axiom auth select              | Select an Axiom deployment                   |
+| axiom auth status              | View authentication status                   |
+| axiom auth switch-org          | Switch the organization                      |
+| axiom auth update-token        | Update the token of a deloyment              |
+| axiom config edit              | Edit the configuration file                  |
+| axiom config get               | Get a configuration value                    |
+| axiom config set               | Set a configuration value                    |
+| axiom dataset create           | Create a dataset                             |
+| axiom dataset delete           | Delete a dataset                             |
+| axiom dataset info             | Get info about a dataset                     |
+| axiom dataset list             | List all datasets                            |
+| axiom dataset stats            | Get statistics about all datasets            |
+| axiom dataset trim             | Trim a dataset to a given size               |
+| axiom dataset update           | Update a dataset                             |
+| axiom organization info        | Get info about an organization               |
+| axiom organization license     | Get an organizations license                 |
+| axiom organization list        | List all organizations                       |
+| axiom organization keys get    | Get shared access keys of an organization    |
+| axiom organization keys rotate | Rotate shared access keys of an organization |
+| axiom token api create         | Create a token                               |
+| axiom token api delete         | Delete a token                               |
+| axiom token personal create    | Create a token                               |
+| axiom token personal delete    | Delete a token                               |
 
 **Additional Commands**
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/axiomhq/axiom-go v0.9.0
+	github.com/axiomhq/axiom-go v0.9.1
 	github.com/axiomhq/pkg v0.3.0
 	github.com/briandowns/spinner v1.18.1
 	github.com/cli/cli v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAm
 github.com/aws/smithy-go v1.9.0 h1:c7FUdEqrQA1/UVKKCNDFQPNKGp4FQg3YW4Ck5SLTG58=
 github.com/aws/smithy-go v1.9.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/axiomhq/axiom-go v0.6.2/go.mod h1:XlcUNUFtdJGj2sf+ImZ5+PQkm+B6mB9Zh0nZCpEQD6E=
-github.com/axiomhq/axiom-go v0.9.0 h1:pnTetdnRsn0fCqcHrTMyFSu7wX180Tr5Ttqf9iKqUoQ=
-github.com/axiomhq/axiom-go v0.9.0/go.mod h1:0Xc4ajOsn9pVGot4KD1JgDheSn4I3+wefuWoKX3uQi8=
+github.com/axiomhq/axiom-go v0.9.1 h1:KA42Cq4QGDZBS2oGzQ12rlPTylxAEDXz2wcF9U24yI4=
+github.com/axiomhq/axiom-go v0.9.1/go.mod h1:0Xc4ajOsn9pVGot4KD1JgDheSn4I3+wefuWoKX3uQi8=
 github.com/axiomhq/pkg v0.3.0 h1:v4scDFPmXB+Wayb8AapIXQcFrBLwr5ERAcevPaIW5GI=
 github.com/axiomhq/pkg v0.3.0/go.mod h1:OjLkiHiN2mO6apKe0RP4vSuhsqhXC4hQGPMt8cTaCmQ=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=

--- a/internal/cmd/auth/auth_login.go
+++ b/internal/cmd/auth/auth_login.go
@@ -121,7 +121,7 @@ func completeLogin(ctx context.Context, opts *loginOptions) error {
 
 	// 3. The token to use.
 	if err := survey.AskOne(&survey.Password{
-		Message: "What is your personal access or ingest token?",
+		Message: "What is your api or personal access token?",
 	}, &opts.Token, survey.WithValidator(survey.ComposeValidators(
 		survey.Required,
 		surveyext.ValidateToken,
@@ -130,7 +130,7 @@ func completeLogin(ctx context.Context, opts *loginOptions) error {
 	}
 
 	// 4. Try to authenticate and fetch the organizations available to the user
-	// in case a Personal Access Token was provided and the deployment is a
+	// in case a Personal Access token was provided and the deployment is a
 	// cloud deployment. If only one organization is available, that one is
 	// selected by default, without asking the user for it.
 	if axiom.IsPersonalToken(opts.Token) && deploymentKind == typeCloud && opts.OrganizationID == "" {
@@ -251,10 +251,10 @@ func runLogin(ctx context.Context, opts *loginOptions) error {
 		} else {
 			if opts.URL == axiom.CloudURL || opts.Config.ForceCloud {
 				fmt.Fprintf(opts.IO.ErrOut(), "%s Logged in to organization %s %s\n",
-					cs.SuccessIcon(), cs.Bold(opts.OrganizationID), cs.Red(cs.Bold("(ingestion only!)")))
+					cs.SuccessIcon(), cs.Bold(opts.OrganizationID), cs.Red(cs.Bold("(ingestion/query only!)")))
 			} else {
 				fmt.Fprintf(opts.IO.ErrOut(), "%s Logged in to deployment %s %s\n",
-					cs.SuccessIcon(), cs.Bold(opts.Alias), cs.Red(cs.Bold("(ingestion only!)")))
+					cs.SuccessIcon(), cs.Bold(opts.Alias), cs.Red(cs.Bold("(ingestion/query only!)")))
 			}
 		}
 	}

--- a/internal/cmd/auth/auth_update_token.go
+++ b/internal/cmd/auth/auth_update_token.go
@@ -65,7 +65,7 @@ func completeUpdateToken(opts *updateTokenOptions) error {
 	}
 
 	return survey.AskOne(&survey.Password{
-		Message: "What is your personal access or ingest token?",
+		Message: "What is your api or personal access token?",
 	}, &opts.Token, survey.WithValidator(survey.ComposeValidators(
 		survey.Required,
 		surveyext.ValidateToken,

--- a/internal/cmd/query/query.go
+++ b/internal/cmd/query/query.go
@@ -84,7 +84,6 @@ func NewQueryCmd(f *cmdutil.Factory) *cobra.Command {
 
 		PreRunE: cmdutil.ChainRunFuncs(
 			cmdutil.NeedsActiveDeployment(f),
-			cmdutil.NeedsPersonalAccessToken(f),
 			cmdutil.NeedsDatasets(f),
 		),
 

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -10,14 +10,16 @@ import (
 
 var topics = map[string]string{
 	"credentials": `
-		The supplied token can either be a Personal Access Token, created from
-		the profile page of the deployment or an Ingest Token, created from the
-		appropriate section in the deployments settings.
+		The supplied access token can either be an API token, retrieved from the
+		settings page of the Axiom deployment (Settings -> API Tokens) or a
+		Personal Access token, retrieved from the users profile page
+		(Settings -> Profile).
 
-		Be aware, that Ingest Tokens are only valid for ingestion! Using them
-		with Axiom CLI is encouraged for ingest-only situations but renders the 
-		CLI unable to do anything else. Use a Personal Access Token to get full
-		access to the deployment.
+		Be aware, that API tokens are only valid for ingestion and querying,
+		depending on their permissions! Using them with Axiom CLI is encouraged
+		for ingest-only and/or query-only situations but renders the CLI unable
+		to do anything else. Use a Personal Access Token to get full access to
+		the deployment.
 	`,
 
 	"environment": `

--- a/internal/cmd/stream/stream.go
+++ b/internal/cmd/stream/stream.go
@@ -59,7 +59,6 @@ func NewStreamCmd(f *cmdutil.Factory) *cobra.Command {
 
 		PreRunE: cmdutil.ChainRunFuncs(
 			cmdutil.NeedsActiveDeployment(f),
-			cmdutil.NeedsPersonalAccessToken(f),
 			cmdutil.NeedsDatasets(f),
 		),
 

--- a/internal/cmd/token/token_create.go
+++ b/internal/cmd/token/token_create.go
@@ -63,7 +63,7 @@ func newCreateCmd(f *cmdutil.Factory, tokenType string) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of the token")
 	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the token")
-	cmd.Flags().StringSliceVarP(&opts.Scopes, "scope", "s", nil, "Scope(s) of the token (for api and ingest token). Dataset name or '*' for all datasets.")
+	cmd.Flags().StringSliceVarP(&opts.Scopes, "scope", "s", nil, "Scope(s) of the token (for api tokens). Dataset name or '*' for all datasets.")
 	cmd.Flags().StringSliceVarP(&opts.Permissions, "permission", "p", nil, "Permission(s) of the token (for api tokens)")
 
 	_ = cmd.RegisterFlagCompletionFunc("name", cmdutil.NoCompletion)

--- a/internal/cmdutil/chain.go
+++ b/internal/cmdutil/chain.go
@@ -50,11 +50,12 @@ var (
 		  $ {{ bold "axiom dataset create nginx-logs" }}
 	`)
 
-	restrictedByIngestTokenMsg = heredoc.Doc(`
-		{{ errorIcon }} Deployment is configured with an Ingest Token!
+	restrictedByAPITokenMsg = heredoc.Doc(`
+		{{ errorIcon }} Deployment is configured with an API token!
 
-		  An Ingest Token is only valid for ingestion. To run {{ bold .CommandPath }}
-		  make sure to use a Personal Access Token. Help on tokens:
+		  An API token is only valid for ingestion and/or querying, depending on
+		  its permissions. To run {{ bold .CommandPath }} make sure to use a
+		  Personal Access token. Help on tokens:
 		  $ {{ bold "axiom help credentials" }}
 
 		  To update the token for the deployment, run:
@@ -192,7 +193,7 @@ func NeedsPersonalAccessToken(f *Factory) RunFunc {
 			return nil
 		}
 
-		err := execTemplateSilent(f.IO, restrictedByIngestTokenMsg, map[string]string{
+		err := execTemplateSilent(f.IO, restrictedByAPITokenMsg, map[string]string{
 			"Deployment":  f.Config.ActiveDeployment,
 			"CommandPath": cmd.CommandPath(),
 		})


### PR DESCRIPTION
This is a follow-up to our most recent changes on phasing out **ingest** tokens in favour of **api** tokens.

This PR unblocks the `stream` and `query` commands and allows the use of api tokens on these commands.

Depends on https://github.com/axiomhq/axiom-go/pull/105.