### PR TITLE
feat(cmd): improve organization listing

### DIFF
--- a/internal/cmd/auth/auth_select.go
+++ b/internal/cmd/auth/auth_select.go
@@ -40,7 +40,7 @@ func newSelectCmd(f *cmdutil.Factory) *cobra.Command {
 			cmdutil.NeedsValidDeployment(f, &activeDeployment),
 		),
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(*cobra.Command, []string) error {
 			if activeDeployment == "" {
 				if err := survey.AskOne(&survey.Select{
 					Message: "Which deployment to select?",

--- a/internal/cmd/organization/organization.go
+++ b/internal/cmd/organization/organization.go
@@ -3,8 +3,10 @@ package organization
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/axiomhq/axiom-go/axiom"
 	"github.com/spf13/cobra"
 
 	"github.com/axiomhq/cli/internal/cmdutil"
@@ -52,7 +54,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, error) {
+func getOrganizations(ctx context.Context, f *cmdutil.Factory) ([]*axiom.Organization, error) {
 	client, err := f.Client(ctx)
 	if err != nil {
 		return nil, err
@@ -66,15 +68,13 @@ func getOrganizationIDs(ctx context.Context, f *cmdutil.Factory) ([]string, erro
 		return nil, err
 	}
 
+	sort.Slice(organizations, func(i, j int) bool {
+		return strings.ToLower(organizations[i].Name) < strings.ToLower(organizations[j].Name)
+	})
+
 	stop()
 
-	organizationIDs := make([]string, len(organizations))
-	for i, organization := range organizations {
-		organizationIDs[i] = organization.ID
-	}
-	sort.Strings(organizationIDs)
-
-	return organizationIDs, nil
+	return organizations, nil
 }
 
 func boolToStr(cs *terminal.ColorScheme, b bool) string {

--- a/internal/cmd/organization/organization_list.go
+++ b/internal/cmd/organization/organization_list.go
@@ -83,7 +83,7 @@ func runList(ctx context.Context, opts *listOptions) error {
 
 	var header iofmt.HeaderBuilderFunc
 	if opts.IO.IsStdoutTTY() {
-		header = func(w io.Writer, trb iofmt.TableRowBuilder) {
+		header = func(_ io.Writer, trb iofmt.TableRowBuilder) {
 			fmt.Fprintf(opts.IO.Out(), "Showing %s:\n\n", utils.Pluralize(cs, "organization", len(organizations)))
 			trb.AddField("ID", cs.Bold)
 			trb.AddField("Name", cs.Bold)


### PR DESCRIPTION
This PR changes (and unifies) how organizations are listed when a user needs to select one (for auth, switching organizations, etc.). Instead of displaying the organizations ID, its display name is listed with the organizations ID alongside it.