### PR TITLE
feat(ci): use GitHub release notes generation API for changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,11 +108,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  use: github-native
 
 milestones:
   - repo:


### PR DESCRIPTION
We use that for most of our non-Go projects as well.