### PR TITLE
error display fix, processedBytes less misleading

### DIFF
--- a/internal/cmd/ingest/ingest.go
+++ b/internal/cmd/ingest/ingest.go
@@ -294,12 +294,14 @@ func run(ctx context.Context, opts *options, flushEverySet bool) error {
 
 	if opts.IO.IsStderrTTY() {
 		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.ErrOut(), "%s processed\n",
+			humanize.Bytes(res.ProcessedBytes),
+		)
 
 		if res.Ingested > 0 {
-			fmt.Fprintf(opts.IO.ErrOut(), "%s Ingested %s (%s)\n",
+			fmt.Fprintf(opts.IO.ErrOut(), "%s Ingested %s\n",
 				cs.SuccessIcon(),
 				utils.Pluralize(cs, "event", int(res.Ingested)),
-				humanize.Bytes(res.ProcessedBytes),
 			)
 		}
 
@@ -310,7 +312,7 @@ func run(ctx context.Context, opts *options, flushEverySet bool) error {
 			)
 			for _, fail := range res.Failures {
 				fmt.Fprintf(opts.IO.ErrOut(), "%s: %s\n",
-					cs.Gray(fail.Timestamp.Format(time.RFC1123)), err,
+					cs.Gray(fail.Timestamp.Format(time.RFC1123)), fail.Error,
 				)
 			}
 		}


### PR DESCRIPTION
We weren't displaying errors correctly, e.g.:

`Mon, 08 Aug 2022 07:51:34 CEST: %!s(<nil>) `


---------

Added a processedBytes line separately, due to potential misleading data (due to processedBytes counting failed and successful events combined):

✓ Ingested 9 events (1.2 MB) // <--total size wrong, should be couple kbs
✖ Failed to ingest 1 event: // <-- this one is 1.2 MB large.

---------

If anyone has a better idea of how to display the processed bytes, e.g. wording, placement, all feedback is welcome.
