### PR TITLE
chore: code grooming

### DIFF
--- a/internal/cmd/auth/auth_login.go
+++ b/internal/cmd/auth/auth_login.go
@@ -128,6 +128,7 @@ func completeLogin(ctx context.Context, opts *loginOptions) error {
 	if opts.Type == "" {
 		if err := survey.AskOne(&survey.Select{
 			Message: "Which kind of Axiom deployment are you using?",
+			Default: validDeploymentTypes[0],
 			Options: validDeploymentTypes,
 		}, &opts.Type, opts.IO.SurveyIO()); err != nil {
 			return err
@@ -211,6 +212,7 @@ func completeLogin(ctx context.Context, opts *loginOptions) error {
 			if err := survey.AskOne(&survey.Select{
 				Message: "Which organization to use?",
 				Options: organizationNames,
+				Default: organizationNames[0],
 				Description: func(_ string, idx int) string {
 					return organizations[idx].ID
 				},
@@ -296,10 +298,10 @@ func autoLogin(ctx context.Context, opts *loginOptions) error {
 		fmt.Fprintln(opts.IO.ErrOut(), "Waiting for authentication...")
 
 		stop = opts.IO.StartActivityIndicator()
-		defer stop()
 
 		return nil
 	}
+	defer stop()
 
 	// Wait five minutes before timing out.
 	authContext, authCancel := context.WithTimeout(ctx, time.Minute*5)

--- a/internal/cmd/auth/auth_logout.go
+++ b/internal/cmd/auth/auth_logout.go
@@ -51,9 +51,11 @@ func newLogoutCmd(f *cmdutil.Factory) *cobra.Command {
 
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if opts.Alias == "" {
+				options := opts.Config.DeploymentAliases()
 				if err := survey.AskOne(&survey.Select{
 					Message: "Which deployment to log out off?",
-					Options: opts.Config.DeploymentAliases(),
+					Default: options[0],
+					Options: options,
 				}, &opts.Alias, opts.IO.SurveyIO()); err != nil {
 					return err
 				}

--- a/internal/cmd/auth/auth_select.go
+++ b/internal/cmd/auth/auth_select.go
@@ -42,9 +42,11 @@ func newSelectCmd(f *cmdutil.Factory) *cobra.Command {
 
 		RunE: func(*cobra.Command, []string) error {
 			if activeDeployment == "" {
+				options := f.Config.DeploymentAliases()
 				if err := survey.AskOne(&survey.Select{
 					Message: "Which deployment to select?",
-					Options: f.Config.DeploymentAliases(),
+					Default: options[0],
+					Options: options,
 				}, &f.Config.ActiveDeployment, f.IO.SurveyIO()); err != nil {
 					return err
 				}

--- a/internal/cmd/auth/auth_switch_org.go
+++ b/internal/cmd/auth/auth_switch_org.go
@@ -63,6 +63,7 @@ func newSwitchOrgCmd(f *cmdutil.Factory) *cobra.Command {
 				var organizationName string
 				if err := survey.AskOne(&survey.Select{
 					Message: "Which organization to use?",
+					Default: organizationNames[0],
 					Options: organizationNames,
 					Description: func(_ string, idx int) string {
 						return organizations[idx].ID

--- a/internal/cmd/dataset/dataset_delete.go
+++ b/internal/cmd/dataset/dataset_delete.go
@@ -80,6 +80,7 @@ func completeDelete(ctx context.Context, opts *deleteOptions) error {
 
 	return survey.AskOne(&survey.Select{
 		Message: "Which dataset to delete?",
+		Default: datasetNames[0],
 		Options: datasetNames,
 	}, &opts.Name, opts.IO.SurveyIO())
 }

--- a/internal/cmd/dataset/dataset_trim.go
+++ b/internal/cmd/dataset/dataset_trim.go
@@ -91,6 +91,7 @@ func completeTrim(ctx context.Context, opts *trimOptions) error {
 			Name: "name",
 			Prompt: &survey.Select{
 				Message: "Which dataset to trim?",
+				Default: datasetNames[0],
 				Options: datasetNames,
 			},
 		})

--- a/internal/cmd/dataset/dataset_update.go
+++ b/internal/cmd/dataset/dataset_update.go
@@ -79,6 +79,7 @@ func completeUpdate(ctx context.Context, opts *updateOptions) error {
 			Name: "name",
 			Prompt: &survey.Select{
 				Message: "Which dataset to update?",
+				Default: datasetNames[0],
 				Options: datasetNames,
 			},
 		})

--- a/internal/cmd/ingest/ingest.go
+++ b/internal/cmd/ingest/ingest.go
@@ -219,6 +219,7 @@ func complete(ctx context.Context, opts *options) error {
 
 	return survey.AskOne(&survey.Select{
 		Message: "Which dataset to ingest into?",
+		Default: datasetNames[0],
 		Options: datasetNames,
 	}, &opts.Dataset, opts.IO.SurveyIO())
 }

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -47,6 +47,20 @@ var topics = map[string]string{
 		CLICOLOR_FORCE: Set to a value other than "0" to keep ANSI colors in
 		output even when the output is piped.
 	`,
+
+	"exit-codes": `
+		gh follows normal conventions regarding exit codes.
+		
+		- If a command completes successfully, the exit code will be 0
+		
+		- If a command fails for any reason, the exit code will be 1
+		
+		- If configuration fails to load, the exit code will be 2
+		
+		NOTE: It is possible that a particular command may have more exit codes,
+		so it is a good practice to check documentation for the command if you
+		are relying on exit codes to control some behavior. 
+	`,
 }
 
 func newHelpTopic(io *terminal.IO, topic string) *cobra.Command {

--- a/internal/cmd/stream/stream.go
+++ b/internal/cmd/stream/stream.go
@@ -116,6 +116,7 @@ func complete(ctx context.Context, opts *options) error {
 
 	return survey.AskOne(&survey.Select{
 		Message: "Which dataset to stream from?",
+		Default: datasetNames[0],
 		Options: datasetNames,
 	}, &opts.Dataset, opts.IO.SurveyIO())
 }

--- a/internal/cmdutil/chain.go
+++ b/internal/cmdutil/chain.go
@@ -151,9 +151,11 @@ func NeedsActiveDeployment(f *Factory) RunFunc {
 			return NewFlagErrorf("--deployment or -D required when not running interactively")
 		}
 
+		options := f.Config.DeploymentAliases()
 		return survey.AskOne(&survey.Select{
 			Message: "Which deployment to use?",
-			Options: f.Config.DeploymentAliases(),
+			Default: options[0],
+			Options: options,
 		}, &f.Config.ActiveDeployment, f.IO.SurveyIO())
 	}
 }


### PR DESCRIPTION
Some code grooming:

1. Fixes a misplaced `defer` statement
2. Makes the first item in a slice the default for `select` terminal ui elements
3. Add help topic on exit codes