### PR TITLE
feat: update ci

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  GOVERSION: "1.18"
-
 jobs:
   gen-diff:
     name: Codegen Diff
@@ -16,14 +13,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - run: make generate man
       - run: git diff --exit-code
 
@@ -35,7 +27,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
+          check-latest: true
+          go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v3
 
   test:
@@ -46,14 +39,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - run: make test
 
   build:
@@ -66,14 +54,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v3
         with:
           args: build --snapshot

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  GOVERSION: "1.18"
-
 jobs:
   gen-diff:
     name: Codegen Diff
@@ -16,14 +13,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - run: make generate man
       - run: git diff --exit-code
 
@@ -35,7 +27,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
+          check-latest: true
+          go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v3
 
   test:
@@ -52,14 +45,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - run: make test
 
   build:
@@ -72,14 +60,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v3
         with:
           args: build --snapshot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v*"
 
-env:
-  GOVERSION: "1.18"
-
 jobs:
   release:
     name: Release
@@ -18,14 +15,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GOVERSION }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          check-latest: true
+          cache: true
+          go-version-file: go.mod
       - uses: docker/login-action@v1
         with:
           registry: docker.io

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/axiomhq/cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
Update CI to use a more recent Go version and utilize the `setup-go` action more properly.