### PR TITLE
client: support HTTPS_PROXY and HTTP_PROXY

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -21,6 +21,7 @@ func New(ctx context.Context, baseURL, accessToken, orgID string, insecure bool)
 	}
 
 	httpTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout: 5 * time.Second,
 		}).DialContext,

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -46,6 +46,15 @@ var topics = map[string]string{
 
 		CLICOLOR_FORCE: Set to a value other than "0" to keep ANSI colors in
 		output even when the output is piped.
+
+		HTTP_PROXY, HTTPS_PROXY (in order of precedence): The URL of the proxy
+		server to use for HTTP or HTTPS requests respectively. The values may be
+		either a complete URL or a "host[:port]", with the "http" scheme assumed.
+		Supported schemes are "http", "https", and "socks5".
+
+		NO_PROXY: A comma-separated list of domain extensions that should bypass
+		the proxy specified by HTTP_PROXY or HTTPS_PROXY. Requests to these domains
+		will not use a proxy.
 	`,
 
 	"exit-codes": `

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -52,9 +52,12 @@ var topics = map[string]string{
 		either a complete URL or a "host[:port]", with the "http" scheme assumed.
 		Supported schemes are "http", "https", and "socks5".
 
-		NO_PROXY: A comma-separated list of domain extensions that should bypass
-		the proxy specified by HTTP_PROXY or HTTPS_PROXY. Requests to these domains
-		will not use a proxy.
+		NO_PROXY: A comma-separated list of hostnames, domains, IP addresses, or
+		CIDR notations that should bypass the proxy specified by HTTP_PROXY or
+		HTTPS_PROXY. Entries may optionally include a port number, formatted as
+		'domain:port' or 'IP:port'. Wildcards (*) can be used for specifying
+		subdomains. For example, "*.example.com" will bypass the proxy for all
+		subdomains of example.com. Requests to these addresses will not use a proxy.
 	`,
 
 	"exit-codes": `

--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -52,12 +52,9 @@ var topics = map[string]string{
 		either a complete URL or a "host[:port]", with the "http" scheme assumed.
 		Supported schemes are "http", "https", and "socks5".
 
-		NO_PROXY: A comma-separated list of hostnames, domains, IP addresses, or
-		CIDR notations that should bypass the proxy specified by HTTP_PROXY or
-		HTTPS_PROXY. Entries may optionally include a port number, formatted as
-		'domain:port' or 'IP:port'. Wildcards (*) can be used for specifying
-		subdomains. For example, "*.example.com" will bypass the proxy for all
-		subdomains of example.com. Requests to these addresses will not use a proxy.
+		NO_PROXY: A comma-separated list of hostnames, domains, IP addresses, or CIDR
+		notations that should bypass the proxy specified by HTTP_PROXY or HTTPS_PROXY.
+		Entries may optionally include a port number, formatted as 'domain:port' or 'IP:port'.
 	`,
 
 	"exit-codes": `


### PR DESCRIPTION
This commit adds support for the standard HTTPS_PROXY and HTTP_PROXY env vars, which allows inspection of HTTP requests with proxies such as mitmproxy, aiding debugging.
