### PR TITLE
fix: terminal output

### DIFF
--- a/internal/cmd/root/help_topic.go
+++ b/internal/cmd/root/help_topic.go
@@ -21,7 +21,7 @@ var topics = map[string]string{
 	`,
 
 	"environment": `
-		AXIOM_DEPLOYMENT: The deployment to use. Overwrittes the choice loaded
+		AXIOM_DEPLOYMENT: The deployment to use. Overwrites the choice loaded
 		from the configuration file.
 
 		AXIOM_ORG_ID: The organization id of the organization the access token
@@ -30,10 +30,10 @@ var topics = map[string]string{
 		AXIOM_PAGER, PAGER (in order of precedence): A terminal paging program
 		to send standard output to, e.g. "less".
 
-		AXIOM_TOKEN: Token The access token to use. Overwrittes the choice
-		loaded from the configuration file.
+		AXIOM_TOKEN: Token The access token to use. Overwrites the choice loaded
+		from the configuration file.
 
-		AXIOM_URL: The deployment url to use. Overwrittes the choice loaded from
+		AXIOM_URL: The deployment url to use. Overwrites the choice loaded from
 		the configuration file.
 
 		VISUAL, EDITOR (in order of precedence): The editor to use for authoring

--- a/internal/cmdutil/chain.go
+++ b/internal/cmdutil/chain.go
@@ -33,11 +33,11 @@ var (
 		  $ {{ bold "axiom auth select" }}
 		  
 		  Select a deployment by setting the {{ bold "AXIOM_DEPLOYMENT" }} environment variable. This
-		  overwrittes the choice made in the configuration file: 
+		  overwrites the choice made in the configuration file: 
 		  $ {{ bold "export AXIOM_DEPLOYMENT=axiom-eu-west-1" }}
 
 		  Select a deployment by setting the {{ bold "-D" }} or {{ bold "--deployment" }} flag. This
-		  overwrittes the choice made in the configuration file or the environment: 
+		  overwrites the choice made in the configuration file or the environment: 
 		  $ {{ bold .CommandPath }} {{ bold "-D=axiom-eu-west-1" }}
 
 		  For non-interactive use, set AXIOM_TOKEN and AXIOM_URL to target a deployment directly,

--- a/pkg/doc/doc.go
+++ b/pkg/doc/doc.go
@@ -17,11 +17,11 @@ func String(s string) string {
 	return unwrap(r)
 }
 
-// Wrap is like Doc() but word wraps at the given width but at max 120
+// Wrap is like Doc() but word wraps at the given width but at max 80
 // characters.
 func Wrap(s string, wrap int) string {
-	if wrap > 120 {
-		wrap = 120
+	if wrap > 80 {
+		wrap = 80
 	}
 	s = String(s)
 	return wordwrap.String(s, wrap)


### PR DESCRIPTION
Some fixes to how documentation/help output is displayed in the terminal. Content is now word-wrapped after 80 instead of 120 characters (or terminal width, if that is less, but that was the case, previously).

Also contains some typo fixes.

Thanks @popey! <3