### PR TITLE
Goreleaser deprecated keys removal/replacement.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -130,7 +130,7 @@ brews:
     description: Powerful log analytics from the comfort of your command-line
     homepage: https://axiom.co
     license: MIT
-    tap:
+    repository:
       owner: axiomhq
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TOKEN }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,7 +80,6 @@ builds:
 archives:
   - <<: &archive_defaults
       name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-      rlcp: true
     id: nix
     builds:
       - darwin


### PR DESCRIPTION
In reference to the following:
https://goreleaser.com/deprecations/#archivesrlcp
https://goreleaser.com/deprecations/#brewstap

The keys have been either removed or replaced accordingly.