### PR TITLE
feat(ingest): support setting fields for csv without header row + csv batching

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,4 +59,7 @@ issues:
       text: "SA1019: client.Datasets.QueryLegacy"
     - linters:
         - staticcheck
+      text: "SA1019: client.QueryLegacy"
+    - linters:
+        - staticcheck
       text: 'SA1019: "github.com/axiomhq/axiom-go/axiom/querylegacy"'

--- a/internal/cmd/query/query.go
+++ b/internal/cmd/query/query.go
@@ -154,7 +154,7 @@ func run(ctx context.Context, opts *options) error {
 	progStop := opts.IO.StartActivityIndicator()
 	defer progStop()
 
-	res, err := client.Datasets.Query(ctx, opts.Query,
+	res, err := client.Query(ctx, opts.Query,
 		query.SetStartTime(opts.startTime),
 		query.SetEndTime(opts.endTime),
 	)


### PR DESCRIPTION
CSV should be batchable as well!

Also adds the CSV headers feature for CSV files without a header row.

In line with https://github.com/axiomhq/axiom-go/pull/305, I also addressed the batching behaviour here and made it less aggressive in time (flush batch every 5s instead of every 1s) but also introduced batch size based flushing (every 10k), whatever condition is met first. Also files are now batched instead of only `stdin` data.