### PR TITLE
fix: revert download-artifact to v4 to fix CI failures

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,7 +93,7 @@ jobs:
       AXIOM_DATASET: cli-test-${{ github.run_id }}-${{ matrix.goos }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v4
       - name: Test (Unix)
         if: matrix.goos == 'darwin' || matrix.goos == 'linux'
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -98,7 +98,7 @@ jobs:
       AXIOM_DATASET: cli-test-${{ github.run_id }}-${{ matrix.goos }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v4
       - name: Test (Unix)
         if: matrix.goos == 'darwin' || matrix.goos == 'linux'
         run: |


### PR DESCRIPTION
## Description

This PR fixes the CI failures introduced by PR #283 which attempted to upgrade `actions/download-artifact` from v4 to v5.

## The Problem

PR #283 (from Dependabot) upgraded `actions/download-artifact` from v4 to v5. However:
1. `actions/upload-artifact` v5 doesn't exist yet (latest is v4)
2. The PR only updated download-artifact to v5 while leaving upload-artifact at v4
3. This version mismatch, combined with path changes in my attempted fix in PR #286, caused CI failures

## The Solution

This PR reverts both upload and download artifact actions back to v4 to maintain consistency. This is the correct approach until upload-artifact v5 is released.

## Changes
- Revert `actions/download-artifact` from v5 back to v4 in both workflow files
- Keep `actions/upload-artifact` at v4 (no v5 exists)
- Maintain the original artifact path structure that works with v4

This restores the CI pipeline to a working state.

Fixes the failures seen in: https://github.com/axiomhq/cli/actions/runs/17068734493/job/48392174733?pr=286