### PR TITLE
cli: fix homebrew cask archive extraction and remove deprecated conflicts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,15 +100,25 @@ archives:
       - man/{{ .ProjectName }}*.1
       - completions/*
   - <<: *archive_defaults
+    id: homebrew
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}_homebrew"
+    ids:
+      - darwin
+    wrap_in_directory: false
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+      - man/{{ .ProjectName }}*.1
+      - completions/*
+  - <<: *archive_defaults
     id: windows
     ids:
       - windows
     wrap_in_directory: false
     formats:
       - zip
-    files:
-      - LICENSE
-      - README.md
 
 checksum:
   name_template: checksums.txt
@@ -138,7 +148,7 @@ homebrew_casks:
     description: Powerful log analytics from the comfort of your command-line
     homepage: https://axiom.co
     ids:
-      - nix
+      - homebrew
     repository:
       owner: axiomhq
       name: homebrew-tap
@@ -147,8 +157,6 @@ homebrew_casks:
       name: axiom-automation
       email: hello@axiom.co
     skip_upload: auto
-    conflicts:
-      - formula: axiom
     manpages:
       - "man/{{ .ProjectName }}*.1"
     completions:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For more information check out the
 
 There are multiple ways you can install the CLI:
 
-- With Homebrew: `brew install axiomhq/tap/axiom`
+- With Homebrew: `brew install --cask axiomhq/tap/axiom`
 - Download the pre-built binary from the
   [GitHub Releases](https://github.com/axiomhq/cli/releases/latest)
 - Using Go: `go install github.com/axiomhq/cli/cmd/axiom@latest`
@@ -57,6 +57,7 @@ CORE COMMANDS
   stream:      Livestream data
 
 MANAGEMENT COMMANDS
+  annotation:  Manage annotations
   auth:        Manage authentication state
   config:      Manage configuration
   dataset:     Manage datasets


### PR DESCRIPTION
Need this to successfully use the `axiom` cask.