### PR TITLE
internal/{config,cmd/config}: write config file with 0600

### DIFF
--- a/internal/cmd/config/config_edit.go
+++ b/internal/cmd/config/config_edit.go
@@ -62,11 +62,16 @@ func newEditCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 
 		PostRunE: func(*cobra.Command, []string) error {
-			f, err := os.Create(f.Config.ConfigFilePath)
+			path := f.Config.ConfigFilePath
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 			if err != nil {
 				return err
 			}
 			defer f.Close()
+
+			if err = os.Chmod(path, 0o600); err != nil {
+				return err
+			}
 
 			if _, err = f.WriteString(content); err != nil {
 				return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,13 +211,18 @@ func (c *Config) Keys() []string {
 }
 
 // Write the configuration to its configuration file on disk. If it doesn't
-// exist, it is created.
+// exist, it is created. The file is written with mode 0o600 so the embedded
+// per-deployment tokens are not exposed to other local users.
 func (c *Config) Write() error {
-	f, err := os.Create(c.ConfigFilePath)
+	f, err := os.OpenFile(c.ConfigFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+
+	if err = os.Chmod(c.ConfigFilePath, 0o600); err != nil {
+		return err
+	}
 
 	// HINT(lukasmalkmus): Rewrite old config files that were talking to
 	// cloud.axiom.co or similar deployments.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config_test
 
 import (
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -54,4 +56,58 @@ func (s *TestConfigSuite) TestLoad() {
 
 	s.Equal("axiom-eu-west-2", cfg.ActiveDeployment)
 	s.Len(cfg.Deployments, 3)
+}
+
+// TestWriteFileMode pins the file mode of the on-disk configuration file at
+// 0o600 so the embedded per-deployment tokens are not exposed to other local
+// users. Covers both a freshly created file and a pre-existing wider-mode file
+// left behind by older CLI versions.
+func TestWriteFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file mode semantics do not apply on Windows")
+	}
+
+	newConfig := func(path string) *config.Config {
+		return &config.Config{
+			ActiveDeployment: "test",
+			ConfigFilePath:   path,
+			Deployments: map[string]config.Deployment{
+				"test": {URL: "https://api.axiom.co", Token: "xaat-secret"},
+			},
+		}
+	}
+
+	t.Run("new file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".axiom.toml")
+		if err := newConfig(path).Write(); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+			t.Errorf("mode = %o, want %o", got, want)
+		}
+	})
+
+	t.Run("existing wider file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), ".axiom.toml")
+		if err := os.WriteFile(path, []byte("active_deployment = \"\"\n"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatalf("seed chmod: %v", err)
+		}
+		if err := newConfig(path).Write(); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+			t.Errorf("mode = %o, want %o", got, want)
+		}
+	})
 }

--- a/pkg/terminal/io.go
+++ b/pkg/terminal/io.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -154,12 +155,9 @@ func (io *IO) StartPager(ctx context.Context) (func(), error) {
 	}
 
 	// Get additional pager configuration from environment.
-	env := os.Environ()
-	for i := len(env) - 1; i >= 0; i-- {
-		if strings.HasPrefix(env[i], "PAGER=") {
-			env = append(env[0:i], env[i+1:]...)
-		}
-	}
+	env := slices.DeleteFunc(os.Environ(), func(s string) bool {
+		return strings.HasPrefix(s, "PAGER=")
+	})
 	if _, ok := os.LookupEnv("LESS"); !ok {
 		env = append(env, "LESS=FRX")
 	}


### PR DESCRIPTION
`Config.Write` and the `axiom config edit` PostRunE used `os.Create`, which lands `~/.axiom.toml` at `0o644` after the standard umask. The file stores per-deployment `xaat-...` personal access tokens, so any other local UID — a daemon, a CI runner with a bind-mounted home, a co-tenant on a multi-user box — can read them and gain full Axiom tenant access.

Both write sites now use `os.OpenFile` with explicit `0o600`, followed by an `os.Chmod(..., 0o600)` so files left behind at `0o644` by older CLI versions get tightened on the next rewrite (`OpenFile`'s mode arg is ignored when the file already exists). `Chmod` errors are fatal — silently continuing leaves the file at the buggy mode and defeats the fix.

A second commit clears a `modernize/slicesbackward` lint finding on `main` from a recent linter bump by switching `pkg/terminal/io.go`'s backward PAGER= drop loop to `slices.DeleteFunc`.

Reported externally via the security disclosure address.

Fixes [AXM-12103](https://linear.app/axiom/issue/AXM-12103/cli-config-file-permissions).

## Testing

New `TestWriteFileMode` in `internal/config/config_test.go` covers two regression cases against `Config.Write`: a freshly created file lands at `0o600`, and a pre-existing `0o644` file is tightened to `0o600` on rewrite. Skipped on Windows where Unix mode bits don't apply. The `config_edit.go` PostRunE shares the same write pattern as `Config.Write` (verified by inspection) but has no test seam — the editor flow is wrapped in a Cobra/survey interactive callback.
