### PR TITLE
skills/axiom-apl: load reference inline instead of forking

### DIFF
--- a/skills/axiom-apl/SKILL.md
+++ b/skills/axiom-apl/SKILL.md
@@ -3,7 +3,6 @@ name: axiom-apl
 description: APL query language reference for Axiom. Provides operators, functions, patterns, and CLI usage. Auto-invoked by specialized Axiom skills when writing or debugging APL queries.
 compatibility: Requires authenticated Axiom CLI (axiom)
 user-invocable: false
-context: fork
 allowed-tools: Bash(axiom query *), Bash(axiom dataset list), Bash(axiom dataset list *), Bash(axiom stream *), Bash(axiom config get *), Read, Grep, Glob
 ---
 


### PR DESCRIPTION
`axiom-apl` is a reference skill: its job is to load APL syntax into the context that's writing a query. `context: fork` ran it in a subagent, so the reference stayed in the fork and never reached the invoking session, forcing a manual re-read of `references/*.md`.

Dropping the line so the reference loads inline. The three task skills (`explore-dataset`, `detect-anomalies`, `find-traces`) keep `context: fork` — they return a report, which forking is correct for.
