### PR TITLE
skills/axiom-apl: document the query diagnostics and the default time range

### DIFF
--- a/skills/axiom-apl/references/cli.md
+++ b/skills/axiom-apl/references/cli.md
@@ -93,6 +93,41 @@ Supported relative units: `w` (week), `d` (day), `h` (hour), `m` (minute), `s` (
 | Table | `-f table` | Human-readable (default) |
 | JSON | `-f json` | Parsing, scripting |
 
+`-f json` writes one JSON object per row to stdout.
+
+### Diagnostics Go To stderr
+
+The command writes results to stdout and diagnostics to stderr. Diagnostics
+are warnings from the server, and the trace id of a failed request.
+
+Read stdout alone when you parse the output:
+
+```bash
+# CORRECT - stdout stays valid JSON
+axiom query "['logs'] | limit 10" -f json --start-time -1h 2>/dev/null | jq .
+
+# WRONG - the warning lines break the parser
+axiom query "['logs'] | limit 10" -f json --start-time -1h 2>&1 | jq .
+```
+
+Two warnings change what the result means:
+
+| Warning | Meaning | Fix |
+|---------|---------|-----|
+| `! A default limit of 1000 was applied` | The result is truncated. | Add `\| limit N` or aggregate. |
+| `! Results are estimated` | The counts are approximate. A `top` over a high-cardinality group does this. | Narrow the range or the group. |
+
+### Trace ID
+
+A failed query prints the trace id of the request on its own line:
+
+```
+Error: API error 400: ...
+Trace: a182bfccdb785f26a6ae6e1ab7a9d1d9
+```
+
+Give this id to Axiom support. It identifies the request server side.
+
 ### Examples
 
 ```bash
@@ -130,7 +165,9 @@ axiom stream logs
 
 ## Query Best Practices
 
-1. **Always specify time range** with `--start-time` to limit data scanned
+1. **Always specify time range** with `--start-time`. Without it the query
+   covers the last 10 years, and `bin_auto` buckets by year. The default limit
+   bounds the rows returned, not the rows read.
 2. **Use JSON for parsing** with `-f json` for programmatic access
 3. **Prefer aggregations** to reduce data volume returned
 4. **Limit results** with `| limit N` during exploration

--- a/skills/axiom-apl/references/gotchas.md
+++ b/skills/axiom-apl/references/gotchas.md
@@ -238,12 +238,57 @@ EOF
 
 ### Problem: Missing time range
 
+Without `--start-time` the query covers the last 10 years. The default limit
+does not prevent this, and a count over time returns yearly buckets.
+
 ```bash
-# WRONG - uses default (might be too broad)
-axiom query "['logs'] | limit 10"
+# WRONG - covers 10 years, buckets by year
+axiom query "['logs'] | summarize count() by bin_auto(_time)"
 
 # CORRECT - explicit time range
-axiom query "['logs'] | limit 10" --start-time -1h
+axiom query "['logs'] | summarize count() by bin_auto(_time)" --start-time -1h
+```
+
+**Rule:** Always pass `--start-time`.
+
+### Problem: Truncated results
+
+Without an explicit limit the result stops at 1000 rows:
+
+```
+! A default limit of 1000 was applied
+```
+
+```bash
+# WRONG - returns the first 1000 rows only
+axiom query "['logs'] | where status == 500" --start-time -1h
+
+# CORRECT - aggregate instead of listing
+axiom query "['logs'] | where status == 500 | count" --start-time -1h
+```
+
+**Rule:** Add `| limit N` or aggregate.
+
+### Problem: Estimated aggregates
+
+A `top` over a high-cardinality group returns approximate counts:
+
+```
+! Results are estimated
+```
+
+**Rule:** Do not report these as exact. Narrow the time range or the group.
+
+### Problem: Parsing output with stderr merged
+
+Diagnostics go to stderr, results to stdout.
+
+```bash
+# WRONG - warning lines end up in the JSON stream
+axiom query "['logs'] | limit 10" -f json --start-time -1h 2>&1 | jq .
+
+# CORRECT
+axiom query "['logs'] | limit 10" -f json --start-time -1h 2>/dev/null | jq .
 ```
 
 ## OTel Field Mismatches


### PR DESCRIPTION
The plugin reference describes the CLI as it was before #390. Three corrections.

**Diagnostics moved to stderr.** `settings.json` pre-approves `axiom query`, so agents run it unprompted. An agent that merges the streams breaks its own parser:

```bash
axiom query "['logs'] | limit 10" -f json 2>&1 | jq .   # the warning line is not JSON
```

The reference now shows the `2>/dev/null` form.

**Two warnings change what a result means.** `! A default limit of 1000 was applied` means the result is truncated. `! Results are estimated` means a `top` over a high-cardinality group returned approximate counts. Both were silent before #390.

**The default time range is 10 years.** The gotcha said "might be too broad". On `axiom-traces-staging`, `summarize count() by bin_auto(_time)`:

| | Rows examined | Buckets | Bucket size |
|-|---------------|---------|-------------|
| no range | 146,792,858,726 | 4 | 1 year |
| `ago(1h)` | 42,948,776 | 121 | 30s |

3400 times the rows, and `bin_auto` sizes buckets from the range, so a count over time returns four yearly bars.

Reference files only, no skill or code changes.
