### PR TITLE
.claude-plugin: tie the plugin version to the CLI version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,21 +6,28 @@
   },
   "metadata": {
     "description": "Axiom CLI plugin marketplace",
-    "version": "1.1.0"
+    "version": "0.16.0"
   },
   "plugins": [
     {
       "name": "axiom-cli",
       "source": "./",
       "description": "APL query assistance and Axiom CLI skills for Claude Code",
-      "version": "1.1.0",
+      "version": "0.16.0",
       "author": {
         "name": "Axiom, Inc."
       },
       "homepage": "https://axiom.co/docs/reference/cli",
       "repository": "https://github.com/axiomhq/cli",
       "license": "MIT",
-      "keywords": ["axiom", "observability", "apl", "logs", "traces", "metrics"]
+      "keywords": [
+        "axiom",
+        "observability",
+        "apl",
+        "logs",
+        "traces",
+        "metrics"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axiom-cli",
-  "version": "1.2.0",
+  "version": "0.16.0",
   "description": "Axiom CLI and APL query assistance for Claude Code",
   "author": {
     "name": "Axiom, Inc.",
@@ -9,5 +9,12 @@
   "homepage": "https://axiom.co/docs/reference/cli",
   "repository": "https://github.com/axiomhq/cli",
   "license": "MIT",
-  "keywords": ["axiom", "observability", "apl", "logs", "traces", "metrics"]
+  "keywords": [
+    "axiom",
+    "observability",
+    "apl",
+    "logs",
+    "traces",
+    "metrics"
+  ]
 }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,7 @@ jobs:
           go-version-file: go.mod
       - run: make generate man
       - run: git diff --exit-code
+      - run: make plugin-version-check
 
   lint:
     name: Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+      - run: make plugin-version-check EXPECT="${GITHUB_REF_NAME#v}"
       - run: echo "GORELEASER_VERSION=$(go list -m -f '{{.Version}}' github.com/goreleaser/goreleaser/v2)" >> $GITHUB_ENV
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ COVERPROFILE	:= coverage.out
 DIST_DIR		:= dist
 MANPAGES_DIR	:= man
 COMPLETIONS_DIR	:= completions
+PLUGIN_MANIFEST		:= .claude-plugin/plugin.json
+PLUGIN_MARKETPLACE	:= .claude-plugin/marketplace.json
 
 # GO TAGS
 GO_TAGS := osusergo netgo static_build
@@ -116,6 +118,27 @@ man: ## Generate man pages
 	@echo ">> generate man pages"
 	@rm -rf $(MANPAGES_DIR)
 	@$(GO) tool gen-cli-docs -d=$(MANPAGES_DIR) -t=$(RELEASE)
+
+.PHONY: plugin-version
+plugin-version: ## Set the Claude Code plugin version. Run with VERSION=x.y.z.
+	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make plugin-version VERSION=0.17.0"; exit 1; }
+	@echo ">> setting plugin version to $(VERSION)"
+	@jq --arg v "$(VERSION)" '.version = $$v' $(PLUGIN_MANIFEST) > $(PLUGIN_MANIFEST).tmp
+	@mv $(PLUGIN_MANIFEST).tmp $(PLUGIN_MANIFEST)
+	@jq --arg v "$(VERSION)" '.metadata.version = $$v | .plugins[].version = $$v' $(PLUGIN_MARKETPLACE) > $(PLUGIN_MARKETPLACE).tmp
+	@mv $(PLUGIN_MARKETPLACE).tmp $(PLUGIN_MARKETPLACE)
+
+.PHONY: plugin-version-check
+plugin-version-check: ## Verify the plugin versions agree. Set EXPECT to also compare a value.
+	@echo ">> checking plugin version"
+	@found=$$(jq -r '.version' $(PLUGIN_MANIFEST); jq -r '.metadata.version, .plugins[].version' $(PLUGIN_MARKETPLACE)); \
+	if [ "$$(echo "$$found" | sort -u | wc -l)" -ne 1 ]; then \
+		echo "plugin versions disagree:"; echo "$$found"; exit 1; \
+	fi; \
+	if [ -n "$(EXPECT)" ] && [ "$$(echo "$$found" | head -1)" != "$(EXPECT)" ]; then \
+		echo "plugin version $$(echo "$$found" | head -1) does not match $(EXPECT)"; \
+		echo "run: make plugin-version VERSION=$(EXPECT)"; exit 1; \
+	fi
 
 .PHONY: test
 test: ## Run all tests. Run with VERBOSE=1 to get verbose test output ('-v' flag).


### PR DESCRIPTION
The plugin carries three version strings, all maintained by hand. They had drifted:

| File | Field | Was |
|------|-------|-----|
| `plugin.json` | `.version` | 1.2.0 |
| `marketplace.json` | `.metadata.version` | 1.1.0 |
| `marketplace.json` | `.plugins[].version` | 1.1.0 |

All three now hold the CLI version, `0.16.0`.

Bump them with one command:

```
make plugin-version VERSION=0.17.0
```

`make plugin-version-check` fails when the three disagree, and compares them to `EXPECT` when it is set. The PR workflow runs it without `EXPECT`, so drift cannot merge. The release workflow runs it with the tag being released:

```
plugin version 0.16.0 does not match 0.17.0
run: make plugin-version VERSION=0.17.0
```

This moves the plugin from 1.2.0 to 0.16.0, which is backwards in semver. Existing installs may not offer the update until the CLI passes 1.2.0.
