### PR TITLE
.claude-plugin: bump the plugin version to 0.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Axiom CLI plugin marketplace",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "plugins": [
     {
       "name": "axiom-cli",
       "source": "./",
       "description": "APL query assistance and Axiom CLI skills for Claude Code",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "author": {
         "name": "Axiom, Inc."
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axiom-cli",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Axiom CLI and APL query assistance for Claude Code",
   "author": {
     "name": "Axiom, Inc.",


### PR DESCRIPTION
Prepares the `v0.17.0` release.

The release workflow checks that the plugin version matches the tag:

```
plugin version 0.16.0 does not match 0.17.0
run: make plugin-version VERSION=0.17.0
```

So this has to land before the tag is cut. Written with `make plugin-version VERSION=0.17.0`, not by hand.
