### PR TITLE
.claude-plugin: bump the plugin version to 0.18.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Axiom CLI plugin marketplace",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "plugins": [
     {
       "name": "axiom-cli",
       "source": "./",
       "description": "APL query assistance and Axiom CLI skills for Claude Code",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "author": {
         "name": "Axiom, Inc."
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axiom-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Axiom CLI and APL query assistance for Claude Code",
   "author": {
     "name": "Axiom, Inc.",


### PR DESCRIPTION
Prepares the v0.18.0 release. The release job runs `make plugin-version-check EXPECT="${GITHUB_REF_NAME#v}"`, so the tag fails unless the plugin manifests already read `0.18.0` on main.

Minor rather than patch because Go 1.27 drops macOS 12. Darwin binaries from this release need macOS 13 or later.
