### PR TITLE
actions/setup: add an action that installs the cli

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Axiom CLI plugin marketplace",
-    "version": "0.18.0"
+    "version": "0.19.0"
   },
   "plugins": [
     {
       "name": "axiom-cli",
       "source": "./",
       "description": "APL query assistance and Axiom CLI skills for Claude Code",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "author": {
         "name": "Axiom, Inc."
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "axiom-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Axiom CLI and APL query assistance for Claude Code",
   "author": {
     "name": "Axiom, Inc.",

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -133,3 +133,23 @@ jobs:
       - name: Cleanup
         if: always()
         run: axiom dataset delete -f ${{ env.AXIOM_DATASET }}
+
+  action:
+    name: Action
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        version:
+          - latest
+          - v0.17.0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./actions/setup
+        with:
+          version: ${{ matrix.version }}
+      - run: axiom version

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -137,3 +137,23 @@ jobs:
       - name: Cleanup
         if: always()
         run: axiom dataset delete -f ${{ env.AXIOM_DATASET }}
+
+  action:
+    name: Action
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        version:
+          - latest
+          - v0.17.0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./actions/setup
+        with:
+          version: ${{ matrix.version }}
+      - run: axiom version

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ There are multiple ways you can install the CLI:
   [GitHub Releases](https://github.com/axiomhq/cli/releases/latest)
 - Using Go: `go install github.com/axiomhq/cli/cmd/axiom@latest`
 - Use the [Docker image](https://hub.docker.com/r/axiomhq/cli): `docker run axiomhq/cli`
+- In GitHub Actions: `uses: axiomhq/cli/actions/setup@v0.19.0`, see
+  [GitHub Action](#github-action)
 
 Run `axiom help` to get familiar with the supported commands:
 
@@ -99,6 +101,22 @@ The default configuration file is `.axiom.toml` located in the home directory.
 Configuration values can also be set using flags or the environment. Flags get
 precedence over environment variables which get precedence over the
 configuration file values.
+
+## GitHub Action
+
+The `actions/setup` action installs the CLI on a workflow runner and adds it to
+`PATH`. It installs the latest release by default:
+
+```yaml
+- uses: axiomhq/cli/actions/setup@v0.19.0
+  with:
+    version: latest # Optional, this is the default.
+- run: axiom query "['my-dataset']"
+  env:
+    AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+```
+
+See [actions/setup](actions/setup/README.md) for the full reference.
 
 ## Claude Code Plugin
 

--- a/actions/setup/README.md
+++ b/actions/setup/README.md
@@ -1,0 +1,33 @@
+# Setup Axiom CLI
+
+Install the [Axiom CLI](https://github.com/axiomhq/cli) and add it to `PATH`.
+
+```yaml
+- uses: axiomhq/cli/actions/setup@v0.19.0
+- run: axiom query "['my-dataset']"
+  env:
+    AXIOM_TOKEN: ${{ secrets.AXIOM_TOKEN }}
+```
+
+## Inputs
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `version` | `latest` | Version to install: a tag like `v0.17.0`, a bare `0.17.0`, or `latest`. |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `version` | The installed version, as a tag, e.g. `v0.17.0`. |
+
+## Details
+
+The action downloads the release archive for the runner's platform, verifies it
+against the release `checksums.txt`, and puts the binary on `PATH`. It does not
+configure authentication. Set `AXIOM_TOKEN`, `AXIOM_ORG_ID`, and `AXIOM_URL` in
+the environment of the steps that need them.
+
+Linux, macOS, and Windows runners are supported on `amd64` and `arm64`. There is
+no `windows/arm64` build. The archive is cached in the runner tool cache, which
+persists on self-hosted runners but not on GitHub-hosted ones.

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -1,0 +1,22 @@
+name: Setup Axiom CLI
+description: Install the Axiom CLI and add it to PATH.
+author: Axiom, Inc.
+
+inputs:
+  version:
+    description: 'Version to install: a tag like "v0.17.0", a bare "0.17.0", or "latest".'
+    default: latest
+
+outputs:
+  version:
+    description: The installed version, as a tag, e.g. "v0.17.0".
+    value: ${{ steps.install.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      run: bash "${GITHUB_ACTION_PATH}/install.sh"
+      env:
+        INPUT_VERSION: ${{ inputs.version }}

--- a/actions/setup/install.sh
+++ b/actions/setup/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Install a released Axiom CLI binary and add it to PATH. Driven by the
+# INPUT_VERSION environment variable, set from the action's `version` input.
+
+set -euo pipefail
+
+readonly repo="axiomhq/cli"
+: "${RUNNER_TOOL_CACHE:=${RUNNER_TEMP:-/tmp}/tool-cache}"
+
+die() {
+	echo "::error::$*"
+	exit 1
+}
+
+case "${INPUT_VERSION:-latest}" in
+latest)
+	# The releases/latest page redirects to the tag. Reading the redirect
+	# target keeps this off api.github.com, which is rate limited per runner
+	# IP and would otherwise need a token.
+	url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${repo}/releases/latest")
+	tag=${url##*/}
+	[[ $tag == v* ]] || die "cannot resolve latest release, got '${tag}' from ${url}"
+	;;
+v*) tag=${INPUT_VERSION} ;;
+*) tag=v${INPUT_VERSION} ;;
+esac
+readonly tag
+readonly version=${tag#v}
+
+case "${RUNNER_OS}" in
+Linux) os=linux ;;
+macOS) os=darwin ;;
+Windows) os=windows ;;
+*) die "unsupported runner OS '${RUNNER_OS}'" ;;
+esac
+readonly os
+
+case "${RUNNER_ARCH}" in
+X64) arch=amd64 ;;
+ARM64) arch=arm64 ;;
+*) die "unsupported runner architecture '${RUNNER_ARCH}', see https://github.com/${repo}/releases for available builds" ;;
+esac
+readonly arch
+
+if [[ $os == windows && $arch == arm64 ]]; then
+	die "there is no windows/arm64 build, see https://github.com/${repo}/releases"
+fi
+
+if [[ $os == windows ]]; then
+	readonly ext=zip binary=axiom.exe
+else
+	readonly ext=tar.gz binary=axiom
+fi
+
+# The tool cache layout matches @actions/tool-cache: the entry lives at
+# <tool>/<version>/<arch> with a sibling <arch>.complete marker, and the arch
+# is the Node os.arch() spelling rather than the Go one.
+dest="${RUNNER_TOOL_CACHE}/axiom/${version}/$(echo "${RUNNER_ARCH}" | tr '[:upper:]' '[:lower:]')"
+# RUNNER_TOOL_CACHE is a backslash path on Windows, which bash reads as escapes.
+readonly dest=${dest//\\//}
+
+publish() {
+	echo "${dest}" >>"${GITHUB_PATH}"
+	echo "version=${tag}" >>"${GITHUB_OUTPUT}"
+}
+
+if [[ -f ${dest}.complete ]]; then
+	echo "axiom ${tag} found in the tool cache"
+	publish
+	exit 0
+fi
+
+tmp=$(mktemp -d)
+readonly tmp
+trap 'rm -rf "${tmp}"' EXIT
+
+readonly archive="axiom_${version}_${os}_${arch}.${ext}"
+readonly base="https://github.com/${repo}/releases/download/${tag}"
+
+echo "Downloading ${archive} from ${tag}"
+curl -fsSL --retry 3 -o "${tmp}/${archive}" "${base}/${archive}" ||
+	die "cannot download ${base}/${archive}"
+curl -fsSL --retry 3 -o "${tmp}/checksums.txt" "${base}/checksums.txt" ||
+	die "cannot download ${base}/checksums.txt"
+
+(
+	cd "${tmp}"
+	grep " ${archive}\$" checksums.txt >checksum ||
+		die "${archive} is not listed in checksums.txt"
+	if command -v sha256sum >/dev/null; then
+		sha256sum -c checksum
+	else
+		shasum -a 256 -c checksum
+	fi
+) || die "checksum verification failed for ${archive}"
+
+if [[ $ext == zip ]]; then
+	# Git Bash ships no unzip and its tar is GNU tar, which cannot read zip.
+	powershell -NoProfile -NonInteractive -Command \
+		"Expand-Archive -LiteralPath '$(cygpath -w "${tmp}/${archive}")' -DestinationPath '$(cygpath -w "${tmp}")' -Force"
+else
+	tar -xzf "${tmp}/${archive}" -C "${tmp}"
+fi
+
+# The nix archives wrap their contents in a directory, the Windows one does not.
+src=$(find "${tmp}" -type f -name "${binary}" -print -quit)
+[[ -n $src ]] || die "${binary} not found in ${archive}"
+
+mkdir -p "${dest}"
+mv "${src}" "${dest}/${binary}"
+chmod +x "${dest}/${binary}"
+: >"${dest}.complete"
+
+echo "Installed axiom ${tag} to ${dest}"
+publish


### PR DESCRIPTION
Adds a composite action that installs the Axiom CLI on a workflow runner.

It downloads the release archive for the runner platform, verifies it against `checksums.txt`, and adds the binary to `PATH`. It installs the latest release by default.

```yaml
- uses: axiomhq/cli/actions/setup@v0.19.0
- run: axiom version
```

Linux, macOS, and Windows work on `amd64` and `arm64`.

The new `action` job in `pr.yaml` and `push.yaml` runs the action on all three runner types, for `latest` and for a pinned version.

The plugin version moves to 0.19.0 for the release that carries the action.
